### PR TITLE
Basic IP white- and blacklisting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -15,6 +15,7 @@ define('VERSION', '2.3.5');
 define('APP_TITLE', 'Tiny File Manager');
 
 // Auth with login/password (set true/false to enable/disable it)
+// Is independent from IP white- and blacklisting
 $use_auth = true;
 
 // Users: array('Username' => 'Password', 'Username2' => 'Password2', ...)
@@ -27,6 +28,27 @@ $auth_users = array(
 // Readonly users (username array)
 $readonly_users = array(
     'user'
+);
+
+// Possible rules are 'OFF', 'AND' or 'OR'
+// OFF => Don't check connection IP, defaults to OFF
+// AND => Connection must be on the whitelist, and not on the blacklist
+// OR => Connection must be on the whitelist, or not on the blacklist
+$ip_ruleset = 'OFF';
+
+// Should users be notified of their block?
+$ip_silent = true;
+
+// IP-addresses, both ipv4 and ipv6
+$ip_whitelist = array(
+    '127.0.0.1',    // local ipv4
+    '::1'           // local ipv6
+);
+
+// IP-addresses, both ipv4 and ipv6
+$ip_blacklist = array(
+    '0.0.0.0',      // non-routable meta ipv4
+    '::'            // non-routable meta ipv6
 );
 
 // user specific directories
@@ -165,6 +187,39 @@ if (isset($_GET['logout'])) {
 // Show image here
 if (isset($_GET['img'])) {
     fm_show_image($_GET['img']);
+}
+
+// Validate connection IP
+if($ip_ruleset != 'OFF'){
+    $clientIp = $_SERVER['REMOTE_ADDR'];
+
+    $proceed = false;
+
+    $whitelisted = in_array($clientIp, $ip_whitelist);
+    $blacklisted = in_array($clientIp, $ip_blacklist);
+
+    if($ip_ruleset == 'AND'){
+        if($whitelisted == true && $blacklisted == false){
+            $proceed = true;
+        }
+    } else
+    if($ip_ruleset == 'OR'){
+         if($whitelisted == true || $blacklisted == false){
+            $proceed = true;
+        }
+    }
+
+    if($proceed == false){
+        trigger_error('User connection denied from: ' . $clientIp, E_USER_WARNING);
+
+        if($ip_silent == false){
+            fm_set_msg('Access denied. IP restriction applicable', 'error');
+            fm_show_header_login();
+            fm_show_message();
+        }
+
+        exit();
+    }
 }
 
 // Auth


### PR DESCRIPTION
Implementation of [#171](https://github.com/prasathmani/tinyfilemanager/issues/171), providing Tiny File Manager with basic IP whitelisting and blacklisting.

I also added a basic editorconfig to the project. This should ensure that all future and present collaborators work with the same indenting and file formatting.

If you have any feedback or further comments, please let me know. I tried to stay as close as possible to existing conventions, but I might have missed something.

Provided by Navigram Technologies, licensed under GNU GPL 3.0