### PR TITLE
Fix spelling of "copyied" after copying file

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -562,7 +562,7 @@ if (isset($_GET['copy'], $_GET['finish']) && !FM_READONLY) {
             }
         } else {
             if (fm_rcopy($from, $dest)) {
-                fm_set_msg(sprintf('Copyied from <b>%s</b> to <b>%s</b>', fm_enc($copy), fm_enc($msg_from)));
+                fm_set_msg(sprintf('Copied from <b>%s</b> to <b>%s</b>', fm_enc($copy), fm_enc($msg_from)));
             } else {
                 fm_set_msg(sprintf('Error while copying from <b>%s</b> to <b>%s</b>', fm_enc($copy), fm_enc($msg_from)), 'error');
             }


### PR DESCRIPTION
It should say "copied".