### PR TITLE
Fix for search function not working if "$hide_Cols=true" on non-Windo…

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -1864,7 +1864,7 @@ $all_files_size = 0;
                 <tfoot>
                     <tr><?php if (!FM_READONLY): ?>
                             <td></td><?php endif; ?>
-                        <td colspan="<?php echo !FM_IS_WIN ? '6' : '4' ?>"><em><?php echo 'Folder is empty' ?></em></td>
+                        <td colspan="<?php echo (!FM_IS_WIN && !$hide_Cols) ? '6' : '4' ?>"><em><?php echo 'Folder is empty' ?></em></td>
                     </tr>
                 </tfoot>
                 <?php
@@ -1873,7 +1873,7 @@ $all_files_size = 0;
                 <tfoot>
                     <tr><?php if (!FM_READONLY): ?>
                             <td class="gray"></td><?php endif; ?>
-                        <td class="gray" colspan="<?php echo !FM_IS_WIN ? '6' : '4' ?>">
+                        <td class="gray" colspan="<?php echo (!FM_IS_WIN && !$hide_Cols) ? '6' : '4' ?>">
                             <?php echo lng('FullSize').': <span class="badge badge-light">'.fm_get_filesize($all_files_size).'</span>' ?>
                             <?php echo lng('File').': <span class="badge badge-light">'.$num_files.'</span>' ?>
                             <?php echo lng('Folder').': <span class="badge badge-light">'.$num_folders.'</span>' ?>


### PR DESCRIPTION
…ws systems

Setting $hide_Cols=true while having FM_IS_WIN=false will lead to a "Type error" when setting up the dataTable. The desired page is generated, but the Search function does not work, as the dataTable is broken.

With this fix the dataTable is written accordingly, with either FM_IS_WIN or $hide_Cols set or unset.