### PR TITLE
Allow defining an upload callback

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -816,10 +816,16 @@ if (!empty($_FILES) && !FM_READONLY) {
             if (move_uploaded_file($tmp_name, $fullPath)) {
                 // Be sure that the file has been uploaded
                 if ( file_exists($fullPath) ) {
-                    $response = array (
-                        'status'    => 'success',
-                        'info' => "file upload successful"
-                    );
+                    $response = null;
+                    if (defined('UPLOAD_CALLBACK')) {
+                        $response = call_user_func(UPLOAD_CALLBACK, $fullPath);
+                    }
+                    if (!is_array($response)) {
+                        $response = array (
+                            'status'    => 'success',
+                            'info' => "file upload successful"
+                        );
+                    }
                 } else {
                     $response = array (
                         'status' => 'error',


### PR DESCRIPTION
What about letting users define a custom function to be called when a file is uploaded?

This is only useful if ` tinyfilemanager.php ` is `include`d by another PHP file, so what about using a simple `defined`-based approach?