### PR TITLE
Create a new session if permission is denied for the current one

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -183,7 +183,17 @@ if (defined('FM_EMBED')) {
 
     session_cache_limiter('');
     session_name(FM_SESSION_ID );
-    @session_start();
+    function session_error_handling_function($code, $msg, $file, $line) {
+        // Permission denied for default session, try to create a new one
+        if ($code == 2) {
+            session_abort();
+            session_id(session_create_id());
+            @session_start();
+        }
+    }
+    set_error_handler('session_error_handling_function');
+    session_start();
+    restore_error_handler();
 }
 
 if (empty($auth_users)) {


### PR DESCRIPTION
In a multi-user configuration, the current session file can be unreadable by the current user. This patch tries to create a new session in this case.