### PR TITLE
Added optional configuration file

### DIFF
--- a/h3k_config.php
+++ b/h3k_config.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+#################################################################################################################
+This is an OPTIONAL configuration file.
+The role of this file is to make updating of "tinyfilemanager.php" easier.
+So you can:
+-Feel free to remove completely this file and configure "tinifilemanager.php" as a single file application.
+or
+-Put inside this file all the static configuration you want and forgot to configure "tinifilemanager.php".
+#################################################################################################################
+*/
+
+// Auth with login/password 
+// set true/false to enable/disable it
+// Is independent from IP white- and blacklisting
+$use_auth = true;
+
+// Login user name and password
+// Users: array('Username' => 'Password', 'Username2' => 'Password2', ...)
+// Generate secure password hash - https://tinyfilemanager.github.io/docs/pwd.html
+$auth_users = array(
+    'admin' => '$2y$10$/K.hjNr84lLNDt8fTXjoI.DBp6PpeyoJ.mGwrrLuCZfAwfSAGqhOW', //admin@123
+    'user' => '$2y$10$Fg6Dz8oH9fPoZ2jJan5tZuv6Z4Kp7avtQ9bDfrdRntXtPeiMAZyGO' //12345
+);
+
+// Readonly users 
+// e.g. array('users', 'guest', ...)
+$readonly_users = array(
+    'user'
+);
+
+// user specific directories
+// array('Username' => 'Directory path', 'Username2' => 'Directory path', ...)
+$directories_users = array();
+
+// Enable highlight.js (https://highlightjs.org/) on view's page
+$use_highlightjs = true;
+
+// highlight.js style
+$highlightjs_style = 'vs';
+
+// Enable ace.js (https://ace.c9.io/) on view's page
+$edit_files = true;
+
+// Default timezone for date() and time()
+// Doc - http://php.net/manual/en/timezones.php
+$default_timezone = 'Etc/UTC'; // UTC
+
+// Root path for file manager
+// use absolute path of directory i.e: '/var/www/folder' or $_SERVER['DOCUMENT_ROOT'].'/folder'
+$root_path = $_SERVER['DOCUMENT_ROOT'];
+
+// Root url for links in file manager.Relative to $http_host. Variants: '', 'path/to/subfolder'
+// Will not working if $root_path will be outside of server document root
+$root_url = '';
+
+// Server hostname. Can set manually if wrong
+$http_host = $_SERVER['HTTP_HOST'];
+
+// input encoding for iconv
+$iconv_input_encoding = 'UTF-8';
+
+// date() format for file modification date
+// Doc - https://www.php.net/manual/en/function.date.php
+$datetime_format = 'd.m.y H:i';
+
+// Allowed file extensions for create and rename files
+// e.g. 'txt,html,css,js'
+$allowed_file_extensions = '';
+
+// Allowed file extensions for upload files
+// e.g. 'gif,png,jpg,html,txt'
+$allowed_upload_extensions = '';
+
+// Favicon path. This can be either a full url to an .PNG image, or a path based on the document root.
+// full path, e.g http://example.com/favicon.png
+// local path, e.g images/icons/favicon.png
+$favicon_path = '?img=favicon';
+
+// Files and folders to excluded from listing
+// e.g. array('myfile.html', 'personal-folder', '*.php', ...)
+$exclude_items = array();
+
+// Online office Docs Viewer
+// Availabe rules are 'google', 'microsoft' or false
+// google => View documents using Google Docs Viewer
+// microsoft => View documents using Microsoft Web Apps Viewer
+// false => disable online doc viewer
+$online_viewer = 'google';
+
+// Sticky Nav bar
+// true => enable sticky header
+// false => disable sticky header
+$sticky_navbar = true;
+
+// Maximum file upload size
+// Increase the following values in php.ini to work properly
+// memory_limit, upload_max_filesize, post_max_size
+define('MAX_UPLOAD_SIZE', '2048');
+
+// Possible rules are 'OFF', 'AND' or 'OR'
+// OFF => Don't check connection IP, defaults to OFF
+// AND => Connection must be on the whitelist, and not on the blacklist
+// OR => Connection must be on the whitelist, or not on the blacklist
+$ip_ruleset = 'OFF';
+
+// Should users be notified of their block?
+$ip_silent = true;
+
+// IP-addresses, both ipv4 and ipv6
+$ip_whitelist = array(
+    '127.0.0.1',    // local ipv4
+    '::1'           // local ipv6
+);
+
+// IP-addresses, both ipv4 and ipv6
+$ip_blacklist = array(
+    '0.0.0.0',      // non-routable meta ipv4
+    '::'            // non-routable meta ipv6
+);
+
+?>

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -126,6 +126,12 @@ $ip_blacklist = array(
     '::'            // non-routable meta ipv6
 );
 
+// Load configuration file, if present
+$config_file = 'h3k_config.php';
+if (is_readable($config_file)) {
+    include($config_file);
+}
+
 // --- EDIT BELOW CAREFULLY OR DO NOT EDIT AT ALL ---
 
 // private key and session name to store to the session


### PR DESCRIPTION
### Optional configuration file
Users can add a **static optional configuration file** in order to make upgrading of tinyfilemanager easier. Deafult name of the configuration file is `h3k_config.php`.

The optional configuration file will be loaded only if it is present. If not present, tinyfilemanager will works with its internal configuration as "single file web app".

### Related to...
[Pull #242](https://github.com/prasathmani/tinyfilemanager/pull/242)
[Issue #199](https://github.com/prasathmani/tinyfilemanager/issues/199)
[Issue #320](https://github.com/prasathmani/tinyfilemanager/issues/320)
[LemPer FM](https://github.com/PHPlayground/tinyfilemanager/tree/lemperfm_1.3.0)