### PR TITLE
Correct wrong word in Vietnamese language.

### DIFF
--- a/translation.json
+++ b/translation.json
@@ -920,7 +920,7 @@
         "Actions": "Hành động",
         "Upload": "Tải lên",
         "Cancel": "Hủy",
-        "InvertSelection": "Lừa chọn đảo ngươc",
+        "InvertSelection": "Lựa chọn đảo ngươc",
         "DestinationFolder": "Thư mục đích",
         "ItemType": "Kiểu",
         "ItemName": "Tên tệp",


### PR DESCRIPTION
"Lừa chọn" <- Wrong
"Lựa chọn" <- Correct