### PR TITLE
Notice: A non well formed numeric value encountered

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2439,6 +2439,7 @@ function fm_get_size($file)
  */
 function fm_get_filesize($size)
 {
+    $size = (float) $size;
     $units = array('B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB');
     $power = $size > 0 ? floor(log($size, 1024)) : 0;
     return sprintf('%s %s', round($size / pow(1024, $power), 2), $units[$power]);


### PR DESCRIPTION
Eliminates the following PHP notices when Error Reporting is turned on:

Notice: A non well formed numeric value encountered in tinyfilemanager.php on line 2443
Notice: A non well formed numeric value encountered in tinyfilemanager.php on line 2444

These notices appear near the top of the screen when viewing the contents of a file.

This happens because PHP floor and round are expecting a (float), not an (int).

Tested under PHP 7.1, 7.2 and 7.3 on Windows.

Let me know if you have any questions.

Best regards,

Michael