### PR TITLE
Write the session to the disk and close it when starting a download

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2921,6 +2921,12 @@ function fm_download_file($fileLocation, $fileName, $chunkSize  = 1024)
         return (false);
     $extension = pathinfo($fileName, PATHINFO_EXTENSION);
 
+	/*
+     * Write the session to the disk and close it here, it's no longer needed
+     * This also allows the user to keep browsing the file share in another tab/window during a download
+	 */
+	session_write_close();
+
     $contentType = fm_get_file_mimes($extension);
     header("Cache-Control: public");
     header("Content-Transfer-Encoding: binary\n");


### PR DESCRIPTION
On my web server, I would have users complain that Tiny File Manager would become unresponsive while the user was downloading, for example attempting to use the UI on a different tab.

Let's say for example you start to download a large file, but you also decide that you want to download another file at the same time, you click on the breadcrumb at the top to navigate back to a different directory to just have your browser sitting there waiting for a response from the server. (at least, that's what happens for me and other users that use Tiny File Manager remotely from my server)

The cause of this is that the session file is locked by the download request, and it is not able to be reacquired by the new session_start attempt or any new requests until the download is complete and the session has been closed and flushed by the download thread.

I am more than happy to sum this up to "It's a Windows thing" as I find it unlikely this would happen in Linux, however if that is the case then perhaps a check for OS could be put in place and the session closed gracefully like I am doing here when Windows is detected.