### PR TITLE
Fix filesize display in file viewer

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -1513,7 +1513,8 @@ if (isset($_GET['view'])) {
 
     $ext = strtolower(pathinfo($file_path, PATHINFO_EXTENSION));
     $mime_type = fm_get_mime_type($file_path);
-    $filesize = fm_get_filesize(filesize($file_path));
+    $filesize_raw = fm_get_size($file_path);
+    $filesize = fm_get_filesize($filesize_raw);
 
     $is_zip = false;
     $is_gzip = false;
@@ -1556,9 +1557,7 @@ if (isset($_GET['view'])) {
                 <p class="break-word"><b><?php echo $view_title ?> "<?php echo fm_enc(fm_convert_win($file)) ?>"</b></p>
                 <p class="break-word">
                     Full path: <?php echo fm_enc(fm_convert_win($file_path)) ?><br>
-                    File
-                    size: <?php echo fm_get_filesize($filesize) ?><?php if ($filesize >= 1000): ?> (<?php echo sprintf('%s bytes', $filesize) ?>)<?php endif; ?>
-                    <br>
+                    File size: <?php echo ($filesize_raw <= 1000) ? "$filesize_raw bytes" : $filesize; ?><br>
                     MIME-type: <?php echo $mime_type ?><br>
                     <?php
                     // ZIP info


### PR DESCRIPTION
The existing page seems to always display the file size as bytes "B" even if it was supposed to show megabytes or kilobytes etc. It also seemed to have a problem with greater than 32 bit file sizes that would wrap around to show the file size as negative a billion bytes or something.

Mainly just copied the implementation from the folder view into the file info view.

Thanks,
Peter