### PR TITLE
Error with determining MIME type for file extensions not listed

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2945,6 +2945,10 @@ function fm_get_file_mimes($extension)
     $fileTypes['php'] = ['application/x-php'];
     $fileTypes['html'] = ['text/html'];
     $fileTypes['txt'] = ['text/plain'];
+    //Unknown mime-types should be 'application/octet-stream'
+    if(empty($fileTypes[$extension])) {
+      $fileTypes[$extension] = ['application/octet-stream'];
+    }
     return $fileTypes[$extension];
 }
 


### PR DESCRIPTION
fm_get_file_mimes() was causing errors for unknown extensions as it was causing an error as array element was not defined and return value was never checked.  According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types and several other resources,  application/octet-stream is the default value for all other cases. An unknown file type should use this type.   I put a check in there to use that by default so a valid value is always returned.

It might be useful to replace this function with the  built-in PHP function mime_content_type() but that adds some additional dependencies as it does not always work out of the box with PHP.