### PR TITLE
feat: add Dockerfile and auto publish.

### DIFF
--- a/.github/workflows/PublishDocker.yml
+++ b/.github/workflows/PublishDocker.yml
@@ -1,0 +1,38 @@
+name: PublishDocker
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '**'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/tinyfilemanager
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# how to build?
+# docker login
+## .....input your docker id and password
+#docker build . -t prasathmani/tinyfilemanager:master
+#docker push prasathmani/tinyfilemanager:master
+
+# how to use?
+# docker run -d -v /absolute/path:/var/www/html/data -p 80:80 --restart=always --name tinyfilemanager prasathmani/tinyfilemanager:master
+
+FROM php:7.4-cli-alpine
+
+# if run in China
+# RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
+
+RUN apk add \
+    libzip-dev \
+    oniguruma-dev
+
+RUN docker-php-ext-install \
+    zip \
+    mbstring \
+    iconv \
+    fileinfo
+
+WORKDIR /var/www/html
+
+COPY tinyfilemanager.php index.php
+COPY config-sample.php config.php
+RUN sed -i "s/\$root_path =.*;/\$root_path = \$_SERVER['DOCUMENT_ROOT'].'\/data';/g" config.php && \
+    sed -i "s/\$root_url = '';/\$root_url = 'data\/';/g" config.php
+
+CMD ["sh", "-c", "php -S 0.0.0.0:80"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,68 @@ To enable/disable authentication set `$use_auth` to true or false.
 
 :information_source: Rename the `config-sample.php` file into `config.php` to use configuration, it is an additional configuration file, Feel free to remove completely this file and configure "tinyfilemanager.php" as a single file application.
 
+### Deploy by Docker
+
+Make sure you have **already installed docker**, [Install reference](https://docs.docker.com/engine/install/)
+
+> **Notice:** Your need an absolute path, and it will be served by tinyfilemanager.
+> 
+> If you want to serve this project at **raspberry pi or another special platform**, you can download project and **build image by yourself**.
+
+You can execute this following commands:
+
+```shell
+$ docker run -d -v /absolute/path:/var/www/html/data -p 80:80 --restart=always --name tinyfilemanager prasathmani/tinyfilemanager:master
+$ docker ps
+CONTAINER ID   IMAGE                                COMMAND                  CREATED         STATUS         PORTS                                       NAMES
+648dfba9c0ff   prasathmani/tinyfilemanager:master   "docker-php-entrypoi…"   4 minutes ago   Up 4 minutes   0.0.0.0:80->80/tcp, :::80->80/tcp           tinyfilemanager
+```
+Access `http://127.0.0.1/` and enter default username and password, then enjoy it.
+
+DockerHub: [https://hub.docker.com/repository/docker/prasathmani/tinyfilemanager](https://hub.docker.com/repository/docker/prasathmani/tinyfilemanager)
+
+#### How to change config within docker
+
+**Important!!!** First, you can copy `config-sample.php` to `config.php`, and must modify this following config
+
+Origin:
+
+```php
+// Root path for file manager
+// use absolute path of directory i.e: '/var/www/folder' or $_SERVER['DOCUMENT_ROOT'].'/folder'
+$root_path = $_SERVER['DOCUMENT_ROOT'];
+
+// Root url for links in file manager.Relative to $http_host. Variants: '', 'path/to/subfolder'
+// Will not working if $root_path will be outside of server document root
+$root_url = '';
+```
+
+Modified:
+
+```php
+// Root path for file manager
+// use absolute path of directory i.e: '/var/www/folder' or $_SERVER['DOCUMENT_ROOT'].'/folder'
+$root_path = $_SERVER['DOCUMENT_ROOT'].'/data';
+
+// Root url for links in file manager.Relative to $http_host. Variants: '', 'path/to/subfolder'
+// Will not working if $root_path will be outside of server document root
+$root_url = 'data/';
+```
+
+Then, change another config what you want, and add a new volume `-v /absolute/path/config.php:/var/www/html/config.php` in `docker run` command, like this:
+
+```shell
+$ docker run -d -v /absolute/path:/var/www/html/data -v /absolute/path/config.php:/var/www/html/config.php -p 80:80 --restart=always --name tinyfilemanager prasathmani/tinyfilemanager:master
+```
+
+#### Stop running
+
+If you want to stop a running docker service, or you want to restart a service, you should stop it first, or you got `docker: Error response from daemon: Conflict. The container name "/tinyfilemanager" is already in use by container ...` problem. You can execute this command:
+
+```shell
+$ docker rm -f tinyfilemanager
+```
+
 ### :loudspeaker: Features
 
 - :cd: Open Source, light and extremely simple


### PR DESCRIPTION
Hi, @prasathmani , I'm already build and test manual build and GithubAction auto build for this. ❤❤❤

I suggest you can merge this code by this following steps:

- Create your DockerHub account, and generate an AccessToken at first.
![image](https://user-images.githubusercontent.com/22190579/131828492-45f60977-bd75-43a0-9e1b-febaedfab39b.png)


- Then add this following secrets in github setting

![image](https://user-images.githubusercontent.com/22190579/131828261-3714788c-9ee8-4744-acb9-86fd6741e1a7.png)

- Merge the code and publish a new version
![image](https://user-images.githubusercontent.com/22190579/131828001-42703d43-7ad1-461c-b9bc-3f336b8b4f4b.png)

- Push Success and check DockerHub
![image](https://user-images.githubusercontent.com/22190579/131828668-7c687010-d8c2-455f-91ea-2d87435ea7b7.png)

- Test docker image with command

Make sure you have **already installed docker**, [Install reference](https://docs.docker.com/engine/install/)

> **Notice:** Your need an absolute path, and it will be served by tinyfilemanager.
> 
> If you want to serve this project at **raspberry pi or another special platform**, you can download project and **build image by yourself**.
You can execute this following commands:

```shell
$ docker run -d -v /absolute/path:/var/www/html/data -p 80:80 --restart=always --name tinyfilemanager prasathmani/tinyfilemanager:master
$ docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED         STATUS         PORTS                                       NAMES
648dfba9c0ff   prasathmani/tinyfilemanager:master   "docker-php-entrypoi…"   4 minutes ago   Up 4 minutes   0.0.0.0:80->80/tcp, :::80->80/tcp           tinyfilemanager
```
Access `http://127.0.0.1/` and enter default username and password, then enjoy it.

![image](https://user-images.githubusercontent.com/22190579/131828816-309bbd7f-fd19-4f3c-8ab3-057d7c0e8bb6.png)
