### PR TITLE
Replace hardcoded configuration path '/config.php' with CONFIG_FILE

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -127,9 +127,8 @@ $ip_blacklist = array(
 );
 
 // if User has the customized config file, try to use it to override the default config above
-$config_file = __DIR__.'/config.php';
-if (is_readable($config_file)) {
-    @include($config_file);
+if (defined('CONFIG_FILE') && is_readable(CONFIG_FILE))) {
+    @include(CONFIG_FILE);
 }
 
 // --- EDIT BELOW CAREFULLY OR DO NOT EDIT AT ALL ---


### PR DESCRIPTION
Replace hardcoded configuration path '/config.php' with CONFIG_FILE named constant. Thus you can embed file manager with different configs.

```
  define('FM_EMBED', true);
  define('CONFIG_FILE', __DIR__.'/config1.php');  // this value can depends on some state
  print(CONFIG_FILE);
  define('FM_SELF_URL', $_SERVER['PHP_SELF']);
  require './tinyfilemanager.php';
```

This PR made possible #444 feature request: "allow user to access multiple directories". Use this scenario: For each target directory define a link which lead to it's own page with embedded file manager instance, having its own CONFIG_FILE. Common configuration options can be included from shared file.

