### PR TITLE
fix: "400 bad request" when saving files

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -3814,7 +3814,7 @@ $isStickyNavBar = $sticky_navbar ? 'navbar-fixed' : 'navbar-normal';
                     url: window.location,
                     // The key needs to match your method's input parameter (case-sensitive).
                     data: JSON.stringify(data),
-                    contentType: "multipart/form-data-encoded; charset=utf-8",
+                    contentType: "application/json; charset=utf-8",
                     //dataType: "json",
                     success: function(mes){toast("Saved Successfully"); window.onbeforeunload = function() {return}},
                     failure: function(mes) {toast("Error: try again");},


### PR DESCRIPTION
In the file editor when saving the file, the request is sent with the header "contentType: "multipart/form-data-encoded; charset=utf-8", in reality though the data is formatted as JSON. On some servers this causes the request to be refused with a status "400: Bad Request" response. 

This PR fixes the wrong header. 