### PR TITLE
Adds json mime type as text type to allow edit json files

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2932,6 +2932,7 @@ function fm_get_text_mimes()
         'application/x-javascript',
         'image/svg+xml',
         'message/rfc822',
+        'application/json',
     );
 }
 


### PR DESCRIPTION
Hi,

First thanks for your awesome tiny file manager.

We discovered that we have files that are json inside so mime type gets detected correctly but they don't have any extension so button to edit them won't show up on the page.

In this PR I just added 'application/json' as valid text mime type returned by your function.

Thanks.