### PR TITLE
Removes some php ext installs as they are already installed in base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,7 @@ RUN apk add \
     oniguruma-dev
 
 RUN docker-php-ext-install \
-    zip \
-    mbstring \
-    iconv \
-    fileinfo
+    zip 
 
 WORKDIR /var/www/html
 


### PR DESCRIPTION
Hi,

In the #845 I mentioned that docker builds seem like fails. Issue is with building iconv lib. I've looked around and it seems this modules are already installed in base image and there is no need to add them again.

Here is an output
```
$ docker run php:7.4-cli-alpine -m 
[PHP Modules]
Core
ctype
curl
date
dom
fileinfo
filter
ftp
hash
iconv
json
libxml
mbstring
mysqlnd
openssl
pcre
PDO
pdo_sqlite
Phar
posix
readline
Reflection
session
SimpleXML
sodium
SPL
sqlite3
standard
tokenizer
xml
xmlreader
xmlwriter
zlib

[Zend Modules]

```

So in this PR I've removed:
* iconv 
* mbstring
* fileinfo

as they are already present in base image.

This PR is also closes #845