### PR TITLE
Remove redundant config option

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -68,10 +68,6 @@ $root_url = '';
 // Server hostname. Can set manually if wrong
 $http_host = $_SERVER['HTTP_HOST'];
 
-// user specific directories
-// array('Username' => 'Directory path', 'Username2' => 'Directory path', ...)
-$directories_users = array();
-
 // input encoding for iconv
 $iconv_input_encoding = 'UTF-8';
 


### PR DESCRIPTION
The user specific directories array gets initialized twice. 
When you add directories to the first one on line 44 it gets overwritten by the second one. 