### PR TITLE
Fix translations dictionary

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -4201,7 +4201,6 @@ function getTranslatableStrings()
         'Logout' => 'Sign Out',
         'Modified' => 'Modified',
         'Move' => 'Move',
-        'Move' => 'Move',
         'Moved from' => 'Moved from',
         'Name' => 'Name',
         'NewItem' => 'New Item',


### PR DESCRIPTION
The English dictionary currently available in the `lng()` method has some missing strings, and some strings are no more used.

I've checked the used strings with the output of
```
xgettext --default-domain=messages --output=test.pot --output-dir=. --language=PHP --from-code=UTF-8 --add-comments=i18n --keyword --keyword=lng:1 --no-escape --add-location tinyfilemanager.php
```

I added the missing strings, and commented out the ones that are no more in use.