### PR TITLE
Bug fix: Delete confirm dialog will work wrong aflter cancel.

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -4008,6 +4008,9 @@ $isStickyNavBar = $sticky_navbar ? 'navbar-fixed' : 'navbar-normal';
         let tpl = $("#js-tpl-confirm").html();
         $(".modal.confirmDailog").remove();
         $('#wrapper').append(template(tpl,tplObj));
+        $("#confirmDialog-"+tplObj.id).on('hidden.bs.modal', function() {
+            $("#confirmDialog-"+tplObj.id).remove();
+        });
         $("#confirmDailog-"+tplObj.id).modal('show');
         return false;
     }

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -4008,10 +4008,9 @@ $isStickyNavBar = $sticky_navbar ? 'navbar-fixed' : 'navbar-normal';
         let tpl = $("#js-tpl-confirm").html();
         $(".modal.confirmDailog").remove();
         $('#wrapper').append(template(tpl,tplObj));
-        $("#confirmDialog-"+tplObj.id).on('hidden.bs.modal', function() {
-            $("#confirmDialog-"+tplObj.id).remove();
-        });
-        $("#confirmDailog-"+tplObj.id).modal('show');
+        const $confirmDailog = $("#confirmDialog-"+tplObj.id);
+        $confirmDailog.on('hidden.bs.modal', function() {$confirmDailog.remove();}
+        $confirmDailog.modal('show');
         return false;
     }
     


### PR DESCRIPTION
Clicking and canceling the delete confirm dialog will cause the information when the last confirmation of deletion is the file/directory information of the first click on the delete button.
Example on [Demo](https://tinyfilemanager.github.io/demo/):
![屏幕录制2023-01-18-09 23 43](https://user-images.githubusercontent.com/46618620/213062758-483f8772-8ef2-4b80-aea1-791fdd7d501b.gif)
