### PR TITLE
Removes sed command from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,5 @@ RUN docker-php-ext-install \
 WORKDIR /var/www/html
 
 COPY tinyfilemanager.php index.php
-RUN sed -i "s/\$root_path =.*;/\$root_path = \$_SERVER['DOCUMENT_ROOT'].'\/data';/g" index.php && \
-    sed -i "s/\$root_url = '';/\$root_url = 'data\/';/g" index.php
 
 CMD ["sh", "-c", "php -S 0.0.0.0:80"]


### PR DESCRIPTION
They were needed before because they changed example config.php to make it workable. Now we don't have it and running sed against main php file just removes a lot of code and forces data path for directory

Example of changes before sed:
```php
// clean and check $root_path
$root_path = rtrim($root_path, '\\/');
$root_path = str_replace('\\', '/', $root_path);
if (!@is_dir($root_path)) {
    echo "<h1>".lng('Root path')." \"{$root_path}\" ".lng('not found!')." </h1>";
    exit;
}
```

becomes after sed:
```php
$root_path = $_SERVER['DOCUMENT_ROOT'].'/data';
$root_path = $_SERVER['DOCUMENT_ROOT'].'/data';
if (!@is_dir($root_path)) {
    echo "<h1>".lng('Root path')." \"{$root_path}\" ".lng('not found!')." </h1>";
    exit;
}
```

thus forcing data as a path and ignores whatever what set in config.php