### PR TITLE
Fixes couple issues with confirmDailog

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -4009,7 +4009,6 @@ $isStickyNavBar = $sticky_navbar ? 'navbar-fixed' : 'navbar-normal';
         $(".modal.confirmDailog").remove();
         $('#wrapper').append(template(tpl,tplObj));
         const $confirmDailog = $("#confirmDailog-"+tplObj.id);
-        $confirmDailog.on('hidden.bs.modal', function() { $confirmDailog.remove(); });
         $confirmDailog.modal('show');
         return false;
     }

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -4008,7 +4008,7 @@ $isStickyNavBar = $sticky_navbar ? 'navbar-fixed' : 'navbar-normal';
         let tpl = $("#js-tpl-confirm").html();
         $(".modal.confirmDailog").remove();
         $('#wrapper').append(template(tpl,tplObj));
-        const $confirmDailog = $("#confirmDialog-"+tplObj.id);
+        const $confirmDailog = $("#confirmDailog-"+tplObj.id);
         $confirmDailog.on('hidden.bs.modal', function() { $confirmDailog.remove(); });
         $confirmDailog.modal('show');
         return false;


### PR DESCRIPTION
There is a typo in naming of confirmDailog id and dialog won't show up. 
Second issue I was getting can't process request from disconnected form error and it seems happens because we destroy form before browser get a chance to process action
```php
        $confirmDailog.on('hidden.bs.modal', function() { $confirmDailog.remove(); });
```
So i've removed this line as we anyway destroy form on next call so we will have one it copy at most.