### PR TITLE
Fixes ajax ability to handle requests when auth disabled

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -423,7 +423,7 @@ unset($p, $use_auth, $iconv_input_encoding, $use_highlightjs, $highlightjs_style
 /*************************** ACTIONS ***************************/
 
 // Handle all AJAX Request
-if (isset($_SESSION[FM_SESSION_ID]['logged'], $auth_users[$_SESSION[FM_SESSION_ID]['logged']]) && isset($_POST['ajax'], $_POST['token']) && !FM_READONLY) {
+if ((isset($_SESSION[FM_SESSION_ID]['logged'], $auth_users[$_SESSION[FM_SESSION_ID]['logged']]) || !FM_USE_AUTH) && isset($_POST['ajax'], $_POST['token']) && !FM_READONLY) {
     if(!verifyToken($_POST['token'])) {
         header('HTTP/1.0 401 Unauthorized');
         die("Invalid Token.");


### PR DESCRIPTION
We lost ability to handle ajax requests (save file for example) if auth is disabled. In this PR I've added check so if auth is disabled it allows ajax requests to proceed.