### PR TITLE
implement static_url to direct link to ressources if reachable via different URL

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -66,6 +66,12 @@ $root_path = $_SERVER['DOCUMENT_ROOT'];
 // Will not working if $root_path will be outside of server document root
 $root_url = '';
 
+// Static ressource URL used only for direct links
+//   comes in handy if fm handles files that are public, but on a different URL
+//   gives users a copy&paste able direct link they can use
+//   eg. https://example.org/foo/file.png where fm is hosted on https://backend.example.org/files/index.php
+$static_url = '';
+
 // Server hostname. Can set manually if wrong
 // $_SERVER['HTTP_HOST'].'/folder'
 $http_host = $_SERVER['HTTP_HOST'];
@@ -237,6 +243,10 @@ $root_url = fm_clean_path($root_url);
 // abs path for site
 defined('FM_ROOT_URL') || define('FM_ROOT_URL', ($is_https ? 'https' : 'http') . '://' . $http_host . (!empty($root_url) ? '/' . $root_url : ''));
 defined('FM_SELF_URL') || define('FM_SELF_URL', ($is_https ? 'https' : 'http') . '://' . $http_host . $_SERVER['PHP_SELF']);
+
+// only used to directly link to ressources
+//$static_url = fm_clean_path($static_url);
+defined('FM_STATIC_URL') || define('FM_STATIC_URL', !empty($static_url) ? $static_url : $FM_ROOT_URL);
 
 // logout
 if (isset($_GET['logout'])) {
@@ -2059,7 +2069,7 @@ $tableTheme = (FM_THEME == "dark") ? "text-white bg-dark table-dark" : "bg-white
                             <a title="<?php echo lng('Rename')?>" href="#" onclick="rename('<?php echo fm_enc(addslashes(FM_PATH)) ?>', '<?php echo fm_enc(addslashes($f)) ?>');return false;"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a>
                             <a title="<?php echo lng('CopyTo')?>..." href="?p=&amp;copy=<?php echo urlencode(trim(FM_PATH . '/' . $f, '/')) ?>"><i class="fa fa-files-o" aria-hidden="true"></i></a>
                         <?php endif; ?>
-                        <a title="<?php echo lng('DirectLink')?>" href="<?php echo fm_enc(FM_ROOT_URL . (FM_PATH != '' ? '/' . FM_PATH : '') . '/' . $f . '/') ?>" target="_blank"><i class="fa fa-link" aria-hidden="true"></i></a>
+                        <a title="<?php echo lng('DirectLink')?>" href="<?php echo fm_enc(FM_STATIC_URL . (FM_PATH != '' ? '/' . FM_PATH : '') . '/' . $f . '/') ?>" target="_blank"><i class="fa fa-link" aria-hidden="true"></i></a>
                     </td>
                 </tr>
                 <?php
@@ -2124,7 +2134,7 @@ $tableTheme = (FM_THEME == "dark") ? "text-white bg-dark table-dark" : "bg-white
                             <a title="<?php echo lng('CopyTo') ?>..."
                                href="?p=<?php echo urlencode(FM_PATH) ?>&amp;copy=<?php echo urlencode(trim(FM_PATH . '/' . $f, '/')) ?>"><i class="fa fa-files-o"></i></a>
                         <?php endif; ?>
-                        <a title="<?php echo lng('DirectLink') ?>" href="<?php echo fm_enc(FM_ROOT_URL . (FM_PATH != '' ? '/' . FM_PATH : '') . '/' . $f) ?>" target="_blank"><i class="fa fa-link"></i></a>
+                        <a title="<?php echo lng('DirectLink') ?>" href="<?php echo fm_enc(FM_STATIC_URL . (FM_PATH != '' ? '/' . FM_PATH : '') . '/' . $f) ?>" target="_blank"><i class="fa fa-link"></i></a>
                         <a title="<?php echo lng('Download') ?>" href="?p=<?php echo urlencode(FM_PATH) ?>&amp;dl=<?php echo urlencode($f) ?>" onclick="confirmDailog(event, 1211, '<?php echo lng('Download'); ?>','<?php echo urlencode($f); ?>', this.href);"><i class="fa fa-download"></i></a>
                     </td>
                 </tr>


### PR DESCRIPTION
Hi,

thx for your nice "tiny" filemanager :)!

i had the usecase, that all files worked on by FM in the backend (like `https://backend-www.example.org/staticwww/index.php`) are actually reachable for the main site (like `https://www.example.org`) without auth.

I've thus implemented a config option `static_url` that is used (only for direct linking) to ressources and is supported to point to a completely different server.

Main purpose being, that direct links are now useable without FM and can be used by the users directly!

In case static_url is not set it should be a no-op and uses FM_ROOT_URL down the line, just like without this patch.

example config:

```
$use_auth = false;
$root_path = "/mnt/data";
$root_url = "/staticwww";
$static_url = "https://www.example.org";
$http_host = "backend-www.example.org"
```

yields the following urls: `https://www.example.org/foo/test.png`

with `static_url` commented out it yields: `https://backend-www.example.org/foo/test.png`