### PR TITLE
 Excluded files and non-allowed extensions + more audio formats embedded

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2854,6 +2854,7 @@ function fm_get_file_icon_class($path)
         case 'flac':
         case 'ac3':
         case 'tds':
+        case 'opus':
             $img = 'fa fa-music';
             break;
         case 'm3u':
@@ -2962,7 +2963,7 @@ function fm_get_video_exts()
  */
 function fm_get_audio_exts()
 {
-    return array('wav', 'mp3', 'ogg', 'm4a');
+    return array('wav', 'mp3', 'ogg', 'opus', 'm4a', 'flac', 'aac');
 }
 
 /**

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -732,7 +732,7 @@ if (isset($_GET['copy'], $_GET['finish']) && !FM_READONLY) {
     $copy = urldecode($_GET['copy']);
     $copy = fm_clean_path($copy);
     // empty path
-    if ($copy == '') {
+    if ($copy == '' || in_array($copy, FM_EXCLUDE_ITEMS)) {
         fm_set_msg(lng('Source path not defined'), 'error');
         $FM_PATH=FM_PATH; fm_redirect(FM_SELF_URL . '?p=' . urlencode($FM_PATH));
     }
@@ -785,7 +785,7 @@ if (isset($_GET['copy'], $_GET['finish']) && !FM_READONLY) {
                $loop_count++;
             }
             if (fm_rcopy($from, $fn_duplicate, False)) {
-                fm_set_msg(sprintf('Copyied from <b>%s</b> to <b>%s</b>', fm_enc($copy), fm_enc($fn_duplicate)));
+                fm_set_msg(sprintf('Copied from <b>%s</b> to <b>%s</b>', fm_enc($copy), fm_enc($fn_duplicate)));
             } else {
                 fm_set_msg(sprintf('Error while copying from <b>%s</b> to <b>%s</b>', fm_enc($copy), fm_enc($fn_duplicate)), 'error');
             }
@@ -2283,7 +2283,10 @@ function fm_rdelete($path)
         $ok = true;
         if (is_array($objects)) {
             foreach ($objects as $file) {
-                if ($file != '.' && $file != '..') {
+                if ($file != '.' && $file != '..' 
+                    && !in_array($file, FM_EXCLUDE_ITEMS) 
+                    && !in_array(strtolower(pathinfo($file, PATHINFO_EXTENSION)), getExcludedExtensions(FM_EXCLUDE_ITEMS))
+                ) {
                     if (!fm_rdelete($path . '/' . $file)) {
                         $ok = false;
                     }
@@ -2314,7 +2317,10 @@ function fm_rchmod($path, $filemode, $dirmode)
         $objects = scandir($path);
         if (is_array($objects)) {
             foreach ($objects as $file) {
-                if ($file != '.' && $file != '..') {
+                if ($file != '.' && $file != '..' 
+                    && !in_array($file, FM_EXCLUDE_ITEMS) 
+                    && !in_array(strtolower(pathinfo($file, PATHINFO_EXTENSION)), getExcludedExtensions(FM_EXCLUDE_ITEMS))
+                ) {
                     if (!fm_rchmod($path . '/' . $file, $filemode, $dirmode)) {
                         return false;
                     }
@@ -2382,7 +2388,10 @@ function fm_rcopy($path, $dest, $upd = true, $force = true)
         $ok = true;
         if (is_array($objects)) {
             foreach ($objects as $file) {
-                if ($file != '.' && $file != '..') {
+                if ($file != '.' && $file != '..' 
+                    && !in_array($file, FM_EXCLUDE_ITEMS) 
+                    && !in_array(strtolower(pathinfo($file, PATHINFO_EXTENSION)), getExcludedExtensions(FM_EXCLUDE_ITEMS))
+                ) {
                     if (!fm_rcopy($path . '/' . $file, $dest . '/' . $file)) {
                         $ok = false;
                     }


### PR DESCRIPTION
- Adds "not allowed" file extension list;
- Tries to prevent uploading, downloading, deleting, ziping, taring, creating, and renaming, files or extensions which are in the excluded list or the "not allowed" list;
-  Add embedded audio player for OPUS, FLAC and AAC since most browsers support playback of those formats/containers by default;