### PR TITLE
Prevent logout issue after page was cached

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -222,7 +222,7 @@ if (defined('FM_EMBED')) {
         mb_regex_encoding('UTF-8');
     }
 
-    session_cache_limiter('');
+    session_cache_limiter('nocache'); // Prevent logout issue after page was cached
     session_name(FM_SESSION_ID );
     function session_error_handling_function($code, $msg, $file, $line) {
         // Permission denied for default session, try to create a new one


### PR DESCRIPTION
Logout may not work otherwise, browser reloads cached page from disk instead of sending GET request ?logout=1 to server.