### PR TITLE
use stream_copy_to_stream

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -969,7 +969,7 @@ if (!empty($_FILES) && !FM_READONLY) {
                 if ($out) {
                     $in = @fopen($tmp_name, "rb");
                     if ($in) {
-                        while ($buff = fread($in, 4096)) { fwrite($out, $buff); }
+                        stream_copy_to_stream($in, $out);
                         $response = array (
                             'status'    => 'success',
                             'info' => "file upload successful"

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -969,7 +969,12 @@ if (!empty($_FILES) && !FM_READONLY) {
                 if ($out) {
                     $in = @fopen($tmp_name, "rb");
                     if ($in) {
-                        stream_copy_to_stream($in, $out);
+                        if (PHP_VERSION_ID < 80009) {
+                            // workaround https://bugs.php.net/bug.php?id=81145
+                            while (!in_array($buff = fread($in, 4096), array("", false), true)) { fwrite($out, $buff); }
+                        } else {
+                            stream_copy_to_stream($in, $out);
+                        }
                         $response = array (
                             'status'    => 'success',
                             'info' => "file upload successful"

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -971,7 +971,7 @@ if (!empty($_FILES) && !FM_READONLY) {
                     if ($in) {
                         if (PHP_VERSION_ID < 80009) {
                             // workaround https://bugs.php.net/bug.php?id=81145
-                            while (!in_array($buff = fread($in, 4096), array("", false), true)) { fwrite($out, $buff); }
+                            while (!feof($in)) { fwrite($out, fread($in, 4096)); }
                         } else {
                             stream_copy_to_stream($in, $out);
                         }


### PR DESCRIPTION
it's simpler, and should be faster.
For example, stream_copy_to_stream can use sendfile ( https://man7.org/linux/man-pages/man2/sendfile.2.html ) on operating systems supporting it, which is faster and use less RAM than fread()+fwrite() (because it avoids copying data to/from userland, doing the copy entirely in-kernel~)