### PR TITLE
login (Redirecting to Main domain of website instead of tfm.php) fix

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -322,11 +322,11 @@ if ($use_auth) {
             if (isset($auth_users[$_POST['fm_usr']]) && isset($_POST['fm_pwd']) && password_verify($_POST['fm_pwd'], $auth_users[$_POST['fm_usr']]) && verifyToken($_POST['token'])) {
                 $_SESSION[FM_SESSION_ID]['logged'] = $_POST['fm_usr'];
                 fm_set_msg(lng('You are logged in'));
-                fm_redirect(FM_ROOT_URL);
+                fm_redirect(FM_SELF_URL);
             } else {
                 unset($_SESSION[FM_SESSION_ID]['logged']);
                 fm_set_msg(lng('Login failed. Invalid username or password'), 'error');
-                fm_redirect(FM_ROOT_URL);
+                fm_redirect(FM_SELF_URL);
             }
         } else {
             fm_set_msg(lng('password_hash not supported, Upgrade PHP version'), 'error');;


### PR DESCRIPTION
When logged in it takes to the website's main URL. For example, if I have tfm in www.example.com/tfm/index.php (index.php is tfm) then after logging in it redirects to www.example.com and then have to press back on the browser then it takes to www.example.com/tfm/index.php

So this fixes this:(Already covered in an issue but not updated yet in file why?) (#1021) 
`fm_redirect(FM_ROOT_URL);`
to
`fm_redirect(FM_SELF_URL);`