### PR TITLE
fix image content (not viewable)

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -1783,7 +1783,7 @@ if (isset($_GET['view'])) {
             } elseif ($is_image) {
                 // Image content
                 if (in_array($ext, array('gif', 'jpg', 'jpeg', 'png', 'bmp', 'ico', 'svg', 'webp', 'avif'))) {
-                    echo '<p><img src="' . fm_enc($file_url) . '" alt="image" class="preview-img-container" class="preview-img"></p>';
+                    echo '<p><img src="' . fm_enc($file_url) . '" alt="" class="preview-img"></p>';
                 }
             } elseif ($is_audio) {
                 // Audio content


### PR DESCRIPTION
Fixed the image content problem where the images were not fit to the size of devices and were not viewable and had to scroll down and up to view the whole big image. With this fix, The whole image is fitted perfectly. (also for different kinds of devices, now its easily viewable and looks good as an image viewer)
IF SOME ARE HAVING CONFUSIONS HERE IS THE EXAMPLE OF WHAT WAS HAPPENING (you can check yourself):

Before:


https://user-images.githubusercontent.com/97784387/233893996-aadb7fb4-eef9-4718-b9bf-c6b2ad57a4e6.mp4

After fix:


https://user-images.githubusercontent.com/97784387/233894052-b79cb962-d98e-4fe6-a6e0-6defc7aa0c9f.mp4

with this code:

```
if (in_array($ext, array('gif', 'jpg', 'jpeg', 'png', 'bmp', 'ico', 'svg', 'webp', 'avif'))) {
                    echo '<p><img src="' . fm_enc($file_url) . '" alt="image" class="preview-img-container" class="preview-img"></p>';
                }
```
                
To this:

```
if (in_array($ext, array('gif', 'jpg', 'jpeg', 'png', 'bmp', 'ico', 'svg', 'webp', 'avif'))) {
                    echo '<p><img src="' . fm_enc($file_url) . '" alt="" class="preview-img"></p>';
                }
```

