### PR TITLE
Add configurable path display modes for better privacy and clarity

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -77,6 +77,12 @@ $iconv_input_encoding = 'UTF-8';
 // Doc - https://www.php.net/manual/en/function.date.php
 $datetime_format = 'm/d/Y g:i A';
 
+// Path display mode when viewing file information
+// 'full' => show full path
+// 'relative' => show path relative to root_path
+// 'host' => show path on the host
+$path_display_mode = 'full';
+
 // Allowed file extensions for create and rename files
 // e.g. 'txt,html,css,js'
 $allowed_file_extensions = '';
@@ -1684,7 +1690,8 @@ if (isset($_GET['view'])) {
         <div class="col-12">
             <p class="break-word"><b><?php echo lng($view_title) ?> "<?php echo fm_enc(fm_convert_win($file)) ?>"</b></p>
             <p class="break-word">
-                <strong>Full path:</strong> <?php echo fm_enc(fm_convert_win($file_path)) ?><br>
+                <?php $display_path = fm_get_display_path($file_path); ?>
+                <strong><?php echo $display_path['label']; ?>:</strong> <?php echo $display_path['path']; ?><br>
                 <strong>File size:</strong> <?php echo ($filesize_raw <= 1000) ? "$filesize_raw bytes" : $filesize; ?><br>
                 <strong>MIME-type:</strong> <?php echo $mime_type ?><br>
                 <?php
@@ -1943,7 +1950,8 @@ if (isset($_GET['chmod']) && !FM_READONLY && !FM_IS_WIN) {
             </h6>
             <div class="card-body">
                 <p class="card-text">
-                    Full path: <?php echo $file_path ?><br>
+                    <?php $display_path = fm_get_display_path($file_path); ?>
+                    <?php echo $display_path['label']; ?>: <?php echo $display_path['path']; ?><br>
                 </p>
                 <form action="" method="post">
                     <input type="hidden" name="p" value="<?php echo fm_enc(FM_PATH) ?>">
@@ -2512,6 +2520,30 @@ function fm_get_parent_path($path)
         return '';
     }
     return false;
+}
+
+function fm_get_display_path($file_path)
+{
+    global $path_display_mode, $root_path, $root_url;
+    switch ($path_display_mode) {
+        case 'relative':
+            return array(
+                'label' => 'Path',
+                'path' => fm_enc(fm_convert_win(str_replace($root_path, '', $file_path)))
+            );
+        case 'host':
+            $relative_path = str_replace($root_path, '', $file_path);
+            return array(
+                'label' => 'Host Path',
+                'path' => fm_enc(fm_convert_win('/' . $root_url . '/' . ltrim(str_replace('\\', '/', $relative_path), '/')))
+            );
+        case 'full':
+        default:
+            return array(
+                'label' => 'Full Path',
+                'path' => fm_enc(fm_convert_win($file_path))
+            );
+    }
 }
 
 /**


### PR DESCRIPTION
This pull request introduces configurable path display modes. The new options improve privacy and clarity for users by allowing the administrator to choose between displaying the full file path, a path relative to the root path, or the host path.

The primary motivation for this change is to hide certain system internals from users who don't need to see them, both for security reasons and to avoid any confusion. Another use is to prevent any confusion when using the Docker image, as the path can be misleading.

Three new display modes have been added:
1. Full Path (default): This mode displays the full path to the file, preserving the original behavior.
2. Relative Root Path: This mode shows the path relative to the root path, which can be useful for providing context without revealing the full system path.
3. Host Path: This mode displays the path on the host, which can be helpful when even the relative path is not meaningful or is potentially confusing (such as when using Docker).

The feature includes a setting in the configuration section, a helper function to handle the path display logic, and updates to the appropriate sections of the code to utilize the new functionality.

Please review the changes and let me know if you have any suggestions or feedback.

If accepted. The [config sample](https://tinyfilemanager.github.io/config-sample.txt) should also be updated to contain the option:
```php
// Path display mode when viewing file information
// 'full' => show full path
// 'relative' => show path relative to root_path
// 'host' => show path on the host
$path_display_mode = 'full';
```