### PR TITLE
reduce feof() calls

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -971,7 +971,15 @@ if (!empty($_FILES) && !FM_READONLY) {
                     if ($in) {
                         if (PHP_VERSION_ID < 80009) {
                             // workaround https://bugs.php.net/bug.php?id=81145
-                            while (!feof($in)) { fwrite($out, fread($in, 4096)); }
+                            do {
+                                for (;;) {
+                                    $buff = fread($in, 4096);
+                                    if ($buff === false || $buff === '') {
+                                        break;
+                                    }
+                                    fwrite($out, $buff);
+                                }
+                            } while (!feof($in));
                         } else {
                             stream_copy_to_stream($in, $out);
                         }


### PR DESCRIPTION
micro-optimization: when doing large file copies, this will reduce the number of feof() calls. for example, if copying 100MB, this will save approximately 25599 feof() calls (256 feof() calls for every MB, except the last one, where it saves 255 feof()'s) - also feof() may do an actual syscall, and syscalls are relatively expensive/time-consuming.

this speeds up file copying of large files when running on PHP < 8.0.9.