### PR TITLE
fix: #52 Does not respect directory tree while uploading a folder containing sub-folders

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -954,7 +954,7 @@ if (!empty($_FILES) && !FM_READONLY) {
 
     $targetPath = $path . $ds;
     if ( is_writable($targetPath) ) {
-        $fullPath = $path . '/' . basename($fullPathInput);
+        $fullPath = $path . '/' . $fullPathInput;
         $folder = substr($fullPath, 0, strrpos($fullPath, "/"));
 
         if (!is_dir($folder)) {


### PR DESCRIPTION
When uploading a folder containing subfolders, all files in the subfolders will be uploaded to the same directory.