### PR TITLE
Remove .swf from video/quicktime

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -3119,7 +3119,6 @@ function fm_get_file_mimes($extension)
     $fileTypes['mpg'] = 'video/mpeg';
     $fileTypes['mpe'] = 'video/mpeg';
     $fileTypes['mov'] = 'video/quicktime';
-    $fileTypes['swf'] = 'video/quicktime';
     $fileTypes['3gp'] = 'video/quicktime';
     $fileTypes['m4a'] = 'video/quicktime';
     $fileTypes['aac'] = 'video/quicktime';


### PR DESCRIPTION
Fixes the issue of .swf file downloads appearing with the file extension of .mov