### PR TITLE
Build 32- and 64-bit ARM docker images via Actions

### DIFF
--- a/.github/workflows/PublishDocker.yml
+++ b/.github/workflows/PublishDocker.yml
@@ -36,6 +36,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ Make sure you have **already installed docker**, [Install reference](https://doc
 
 > **Notice:** Your need an absolute path, and it will be served by tinyfilemanager.
 > 
-> If you want to serve this project at **raspberry pi or another special platform**, you can download project and **build image by yourself**.
+> If you want to run this image on any other architecture than one of the following, you can clone this repository and build the image yourself:
+* `linux/amd64`
+* `linux/arm64`
+* `linux/arm/v7`
 
 You can execute this following commands:
 


### PR DESCRIPTION
Fixes #1084. No change to image needed.

Tested amd64 and arm64, I don't have anything running arm/v7.

Images for review at https://hub.docker.com/r/bityard/tinyfilemanager