### PR TITLE
Add --no-cache to 'apk add' command in order to reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM php:7.4-cli-alpine
 # if run in China
 # RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories
 
-RUN apk add \
+RUN apk add --no-cache \
     libzip-dev \
     oniguruma-dev
 


### PR DESCRIPTION
This is a best practice for Docker images to keep the created image as small as possible. So there is no need to installation packages to be stored on the image. this attribute asks apk to do not cache them on the filesystem.