### PR TITLE
Add JSON Parse Error Handling in Upload Script

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -1400,12 +1400,12 @@ if (isset($_GET['upload']) && !FM_READONLY) {
                 }).on("success", function (res) {
                     try {
                         let _response = JSON.parse(res.xhr.response);
+
+                        if(_response.status == "error") {
+                            toast(_response.info);
+                        }
                     } catch (e) {
                         toast("Error: Invalid JSON response");
-                    }
-
-                    if(_response.status == "error") {
-                        toast(_response.info);
                     }
                 }).on("error", function(file, response) {
                     toast(response);

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -1398,11 +1398,11 @@ if (isset($_GET['upload']) && !FM_READONLY) {
                         toast('Error: Server Timeout');
                     });
                 }).on("success", function (res) {
-					try {
-						let _response = JSON.parse(res.xhr.response);
-					} catch (e) {
-						toast("Error: Invalid JSON response");
-					}
+                    try {
+                        let _response = JSON.parse(res.xhr.response);
+                    } catch (e) {
+                        toast("Error: Invalid JSON response");
+                    }
 
                     if(_response.status == "error") {
                         toast(_response.info);

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -1398,7 +1398,11 @@ if (isset($_GET['upload']) && !FM_READONLY) {
                         toast('Error: Server Timeout');
                     });
                 }).on("success", function (res) {
-                    let _response = JSON.parse(res.xhr.response);
+					try {
+						let _response = JSON.parse(res.xhr.response);
+					} catch (e) {
+						toast("Error: Invalid JSON response");
+					}
 
                     if(_response.status == "error") {
                         toast(_response.info);


### PR DESCRIPTION
The directory specified by "$tmp_name = $f['file']['tmp_name'];" may sometimes be inaccessible. When this occurs, the information returned by "res.xhr.response" can be erroneous, and there are no error prompts to indicate the issue. 