### PR TITLE
the  function posix_getpwuid return leads to the main page not show entirely.

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2153,19 +2153,29 @@ $all_files_size = 0;
                 $filesize_raw = "";
                 $filesize = lng('Folder');
                 $perms = substr(decoct(fileperms($path . '/' . $f)), -4);
+                $owner = array('name' => '?'); 
+                $group = array('name' => '?');
                 if (function_exists('posix_getpwuid') && function_exists('posix_getgrgid')) {
-                    $owner = posix_getpwuid(fileowner($path . '/' . $f));
-                    $group = posix_getgrgid(filegroup($path . '/' . $f));
-                    if ($owner === false) {
-                        $owner = array('name' => '?');
+                    try{
+                        $owner_id = fileowner($path . '/' . $f);
+                        if($owner_id != 0) {
+                            $owner_info = posix_getpwuid($owner_id);
+                           if ($owner_info) {
+                                  $owner =  $owner_info;
+                           }
+                       }
+                      
+                        $group_id = filegroup($path . '/' . $f);
+                        $group_info = posix_getgrgid($group_id);
+                        if ($group_info) {
+                             $group =  $group_info;
+                         }
+
+                    } catch(Exception $e){
+                       error_log("exception:" . $e->getMessage());
                     }
-                    if ($group === false) {
-                        $group = array('name' => '?');
-                    }
-                } else {
-                    $owner = array('name' => '?');
-                    $group = array('name' => '?');
                 }
+
             ?>
                 <tr>
                     <?php if (!FM_READONLY): ?>
@@ -2218,19 +2228,29 @@ $all_files_size = 0;
                 $filelink = '?p=' . urlencode(FM_PATH) . '&amp;view=' . urlencode($f);
                 $all_files_size += $filesize_raw;
                 $perms = substr(decoct(fileperms($path . '/' . $f)), -4);
+                $owner = array('name' => '?'); 
+                $group = array('name' => '?');
                 if (function_exists('posix_getpwuid') && function_exists('posix_getgrgid')) {
-                    $owner = posix_getpwuid(fileowner($path . '/' . $f));
-                    $group = posix_getgrgid(filegroup($path . '/' . $f));
-                    if ($owner === false) {
-                        $owner = array('name' => '?');
+                    try{
+                        $owner_id = fileowner($path . '/' . $f);
+                        if($owner_id != 0) {
+                            $owner_info = posix_getpwuid($owner_id);
+                           if ($owner_info) {
+                                  $owner =  $owner_info;
+                           }
+                       }
+                      
+                        $group_id = filegroup($path . '/' . $f);
+                        $group_info = posix_getgrgid($group_id);
+                        if ($group_info) {
+                             $group =  $group_info;
+                         }
+
+                    } catch(Exception $e){
+                       error_log("exception:" . $e->getMessage());
                     }
-                    if ($group === false) {
-                        $group = array('name' => '?');
-                    }
-                } else {
-                    $owner = array('name' => '?');
-                    $group = array('name' => '?');
                 }
+
             ?>
                 <tr>
                     <?php if (!FM_READONLY): ?>


### PR DESCRIPTION
running envirement: Android 4.4+PHP 7.4.3+ KSWEB
http://192.168.1.2/tinyfilemanager.php, afer login,the main page could not be showed entirely,it just shows half of navigation bar.

that's becuase of
there are two same lines of codes which cause the problem. they are $owner = posix_getpwuid(fileowner($path . '/' . $f)); when the funciton fileowner($path . '/' . $f)  return 0 and  run the function posix_getpwuid(....)  at next step, it trig an error.  please check the codes in line 2156--2168 and 2221--2233.

suggest replace these two parts with followed  codes:
                $owner = array('name' => '?');
                $group = array('name' => '?');
                if (function_exists('posix_getpwuid') && function_exists('posix_getgrgid')) {
                    try{
                        $owner_id = fileowner($path . '/' . $f);
                        if($owner_id != 0) {
                            $owner_info = posix_getpwuid($owner_id);
                           if ($owner_info) {
                                  $owner =  $owner_info;
                           }
                       }

                        $group_id = filegroup($path . '/' . $f);
                        $group_info = posix_getgrgid($group_id);
                        if ($group_info) {
                             $group =  $group_info;
                         }

                    } catch(Exception $e){
                       error_log("exception:" . $e->getMessage());
                    }
                }