### PR TITLE
Added ACE's font size and theme variables

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -170,6 +170,9 @@ if (is_readable($config_file)) {
     @include($config_file);
 }
 
+define('ACE_FONTSIZE', isset($ace_fontsize) ? $ace_fontsize : 12);
+define('ACE_THEME', isset($ace_theme) ? $ace_theme : 'textmate');
+
 // External CDN resources that can be used in the HTML (replace for GDPR compliance)
 $external = array(
     'css-bootstrap' => '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">',
@@ -5204,7 +5207,7 @@ function fm_show_header_login()
                     path: "ace/mode/<?php echo $ext; ?>",
                     inline: true
                 });
-                //editor.setTheme("ace/theme/twilight"); // Dark Theme
+                editor.setTheme("ace/theme/<?php echo ACE_THEME; ?>"); // Dark Theme
                 editor.setShowPrintMargin(false); // Hide the vertical ruler
                 function ace_commend(cmd) {
                     editor.commands.exec(cmd, editor);
@@ -5463,8 +5466,9 @@ function fm_show_header_login()
                     $modeEl.val(editor.getSession().$modeId);
                     $themeEl.val(editor.getTheme());
                     $(function() {
-                        //set default font size in drop down
-                        $fontSizeEl.val(12).change();
+                        // Apply font size directly, then sync dropdown
+                        editor.setFontSize(<?php echo (int) ACE_FONTSIZE; ?>);
+                        $fontSizeEl.val(<?php echo (int) ACE_FONTSIZE; ?>);
                     });
                 }
 


### PR DESCRIPTION
Setting the font size and theme every single time I edit a file is annoying. This PR address issue #1171.

That issue was about adding global variables to change the ACE editor theme and font size in `config.php`, the same way it happens in other configurations. PR #1200 only partially solved the issue of the font size not changing when editing `tinyfilemanager.php` directly.

With this PR I added global constants defined right after the inclusion of the config.php file. Their values ​​are conditional, and depend on whether or not there are variables defined in config.php. The code is super short, and easy to understand, it only changes 4 lines.

If you want to set custom values, just include these lines in config.php:

```
$ace_fontsize = 18;
$ace_theme = 'dracula';
```
Default values are `12` and `textmate`.

I tried using normal global variables instead of using constants, but it didn't work. For some reason when I add `<?php echo $variable; ?>` to set font size and theme it doesn't work, but when I use constant it works: `<?php echo CONSTANT; ?>`.

I'm open to suggestions, it's always good to learn.