### PR TITLE
support plaintext passwords

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -328,6 +328,7 @@ if ($use_auth) {
     function tfm_password_verify(
         #[\SensitiveParameter]
         string $password,
+        #[\SensitiveParameter]
         string $hash
     ): bool {
         // CRYPT_MD5: $1$

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -334,7 +334,7 @@ if ($use_auth) {
             if (PHP_MAJOR_VERSION >= 8) {
                 return str_starts_with($haystack, $needle);
             }
-            return strlen($needle) <= strlen($haystack) && 0 === substr_compare($haystack, $needle, 0);
+            return 0 === substr_compare($haystack, $needle, 0, strlen($needle));
         };
         $needles = array(
             '$1$', // CRYPT_MD5,

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -330,7 +330,7 @@ if ($use_auth) {
         string $password,
         #[\SensitiveParameter]
         string $hash
-    ): bool {
+    )/*: bool*/ {
         // CRYPT_MD5: $1$
         // CRYPT_BLOWFISH: $2a$, $2x$, $2y$
         // CRYPT_SHA256: $5$

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -327,9 +327,9 @@ if ($ip_ruleset != 'OFF') {
 if ($use_auth) {
     function tfm_password_verify(
         #[\SensitiveParameter]
-        string $password,
+        /*string*/ $password,
         #[\SensitiveParameter]
-        string $hash
+        /*string*/ $hash
     )/*: bool*/ {
         // CRYPT_MD5: $1$
         // CRYPT_BLOWFISH: $2a$, $2x$, $2y$


### PR DESCRIPTION
Shouldn't be encouraged, but sometimes you actually do want
```php
$auth_users = array(
    'admin' => 'admin@123'
);
```