### PR TITLE
fix config save opcache delay

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -570,6 +570,7 @@ if ((isset($_SESSION[FM_SESSION_ID]['logged'], $auth_users[$_SESSION[FM_SESSION_
             $theme = $te3;
         }
         $cfg->save();
+        session_write_close();
         echo true;
     }
 


### PR DESCRIPTION
If you had opcache installed, settings changes would not be immediately applied, leading to the
![image](https://github.com/user-attachments/assets/2c649d08-9232-4232-b27d-b68b90219eb4)

>Sometimes the save action may not work on the first try, so please attempt it again.

text.

Opcache is bundled in php core as of php5.5.0, compiled by default in php-fpm, and is a very popular extension. It's basically ubiquitous.