### PR TITLE
Existing File Upload Conflict Option

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -1055,19 +1055,23 @@ if (!empty($_FILES) && !FM_READONLY) {
                     if (file_exists($fullPath)) {
                         $ext_1 = $ext ? '.' . $ext : '';
                         $datedPath = $path . '/' . basename($fullPathInput, $ext_1) . '_' . date('ymdHis') . $ext_1;
-                        switch($upload_name_conflict_handling)
-                        {
-                            case 'OLD':
-                                rename($fullPath,$datedPath);
-                                break;
-                            case 'REPLACE':
-                                if( fm_rdelete($fullPath) ) break;
-                            case 'NEW':
-                            default:
-                                $fullPathTarget = $datedPath;
+                        if(fm_is_exclude_items($fullPath)){
+                            $fullPathTarget = $datedPath; // excluded items should not be replaced or renamed
+                        }else{
+                            switch($upload_name_conflict_handling)
+                            {
+                                case 'OLD':
+                                    fm_rename($fullPath,$datedPath);
+                                    break;
+                                case 'REPLACE':
+                                    if(fm_rdelete($fullPath)) break;
+                                case 'NEW':
+                                default:
+                                    $fullPathTarget = $datedPath;
+                            }
                         }
                     }
-                    rename("{$fullPath}.part", $fullPathTarget);
+                    fm_rename("{$fullPath}.part", $fullPathTarget);
                 }
             } else if (move_uploaded_file($tmp_name, $fullPath)) {
                 // Be sure that the file has been uploaded


### PR DESCRIPTION
When uploading a file that already exists, the code will currently append a timestamp to the end of the file to avoid overwriting.  Previous advice was to remove an if statement to overwrite the file #1133.

This PR adds configuration option `$upload_name_conflict_handling` with the following logic:

- `NEW` : The newly uploaded file is renamed with a timestamp (current behaviour)
- `OLD` : The old file is renamed with a timestamp, new file keeps desired name. (my recommended default)
- `REPLACE` : The old file is deleted before the new file keeps the desired name. Fallback to `NEW` if the delete operation fails.

As a security precaution, if the existing file is in `$exclude_items`, the upload will fall back to the current `NEW` behaviour.

Closes #938 (technically already closed), Closes #1211