### PR TITLE
File Upload Conflict Prompt & Rename fm_is_exclude_items

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -4953,7 +4953,7 @@ function fm_show_header_login()
                 if (remaining_count > 0) {
                     $('.conflict-checkbox-container').show();
                     $('#conflict_checkbox').prop('checked', false);
-                    $('.conflict-checkbox-container label').html('<?php echo lng('Apply choice to remaining ') ?> <b>' + remaining_count + '</b>');
+                    $('.conflict-checkbox-container label').html('<?php echo lng('Apply choice to remaining') ?> <b>' + remaining_count + '</b>');
                 } else {
                     $('.conflict-checkbox-container').hide();
                     $('#conflict_checkbox').prop('checked', false);
@@ -5708,6 +5708,12 @@ function fm_show_header_login()
         $tr['en']['Actions']        = 'Actions';
         $tr['en']['Folder is empty'] = 'Folder is empty';
         $tr['en']['Upload']         = 'Upload';
+        $tr['en']['File conflict detected'] = 'File conflict detected';
+        $tr['en']['Conflict detected for'] = 'Conflict detected for';
+        $tr['en']['New Filename'] = 'New Filename';
+        $tr['en']['Rename Old'] = 'Rename Old';
+        $tr['en']['Apply choice to remaining'] = 'Apply choice to remaining';
+        $tr['en']['Replace'] = 'Replace';
         $tr['en']['Cancel']         = 'Cancel';
         $tr['en']['InvertSelection'] = 'Invert Selection';
         $tr['en']['DestinationFolder']  = 'Destination Folder';


### PR DESCRIPTION
Enhanced from my previously closed PR #1312. Closes #938 (technically already closed), Closes #1211

First off, I've refactored `fm_is_exclude_items` to `fm_is_excluded`. The logic was backwards from what the function name implied. I've inverted any reference to the previous function name. (commit ce1d720) 

Just at in my previous PR, this adds `$upload_name_conflict_handling` configuration option with the following options:
- `NEW` : The newly uploaded file is renamed with a timestamp (current behaviour)
- `OLD` : The old file is renamed with a timestamp, new file keeps desired name. (my recommended default)
- `REPLACE` : The old file is deleted before the new file keeps the desired name.
- Finally, `PROMPT` will leave the uploaded file as `.part` and trigger a conflict resolution dialog.

For the `PROMPT` option, Dropzone will listen for a successful upload with a 'conflict' status to launch the dialog. If multiple conflicting files are uploaded simultaneously, the user has the option to apply their choice to the whole queue of conflicting files. If the user closes the tab or chooses to cancel, the file will remain as `.part`

Again, if any of the uploaded files exist and are excluded items, the `NEW` option is fallback.

Approving this PR will create an issue to add six new lines to be translated. b99e6be
