### PR TITLE
fix: 部分虚拟机提供商的HTTPS值为ON，导致['HTTPS'] == 'on'失效，转换为小写后比较

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -257,7 +257,7 @@ if (empty($auth_users)) {
     $use_auth = false;
 }
 
-$is_https = isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] == 1)
+$is_https = isset($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) == 'on' || $_SERVER['HTTPS'] == 1)
     || isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https';
 
 // update $root_url based on user specific directories


### PR DESCRIPTION
主机实际值：$_SERVER['HTTPS'] => "ON"
判断是否HTTPS : $_SERVER['HTTPS'] == 'on'
修复：strtolower($_SERVER['HTTPS']) == 'on'