### PR TITLE
Fix language code capitalisation.

### DIFF
--- a/translation.json
+++ b/translation.json
@@ -247,7 +247,7 @@
     },
     {
       "name": "فارسی",
-      "code": "Fa",
+      "code": "fa",
       "translation": {
         "Tiny File Manager": "مدیریت فایل کوچک",
         "File Manager": "مدیریت فایل",
@@ -1881,7 +1881,7 @@
     },
     {
       "name": "العربية",
-      "code": "Ar",
+      "code": "ar",
       "translation": {
         "AppName": "مدير الملفات الصغير",
         "AppTitle": "مدير الملفات",


### PR DESCRIPTION
All language codes other than that for Farsi (Persian) and Arabic follow a format of `xx` or `xx-XX`, consistent with ISO 639-1. Those said two language codes, however, had their first letter capitalised (`Xx`). This pull request normalises them so as to be consistent with all the others.