### PR TITLE
Fix editor save handling for expired sessions

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -274,6 +274,15 @@ if (empty($_SESSION['token'])) {
     }
 }
 
+// Parse JSON AJAX save requests before checking authentication
+$contentType = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';
+if (stripos($contentType, 'application/json') !== false) {
+    $jsonPost = json_decode(file_get_contents('php://input'), true);
+    if (is_array($jsonPost) && !empty($jsonPost['ajax']) && isset($jsonPost['type']) && $jsonPost['type'] === 'save') {
+        $_POST = $jsonPost;
+    }
+}
+
 if (empty($auth_users)) {
     $use_auth = false;
 }
@@ -367,6 +376,12 @@ if ($use_auth) {
     } else {
         // Form
         unset($_SESSION[FM_SESSION_ID]['logged']);
+        if (!empty($_POST['ajax']) && isset($_POST['type']) && $_POST['type'] === 'save') {
+            header('HTTP/1.1 401 Unauthorized');
+            header('Content-Type: text/plain; charset=UTF-8');
+            header('Cache-Control: no-store');
+            die("Session expired. The file was not saved. Log in again in another tab, then click Save again.");
+        }
         fm_show_header_login();
 ?>
         <section class="h-100">
@@ -462,10 +477,6 @@ $p = isset($_GET['p']) ? $_GET['p'] : (isset($_POST['p']) ? $_POST['p'] : '');
 // clean path
 $p = fm_clean_path($p);
 
-// for ajax request - save
-$input = file_get_contents('php://input');
-$_POST = (strpos($input, 'ajax') != FALSE && strpos($input, 'save') != FALSE) ? json_decode($input, true) : $_POST;
-
 // instead globals vars
 define('FM_PATH', $p);
 define('FM_USE_AUTH', $use_auth);
@@ -482,6 +493,13 @@ unset($p, $use_auth, $iconv_input_encoding, $use_highlightjs, $highlightjs_style
 // Handle all AJAX Request
 if ((isset($_SESSION[FM_SESSION_ID]['logged'], $auth_users[$_SESSION[FM_SESSION_ID]['logged']]) || !FM_USE_AUTH) && isset($_POST['ajax'], $_POST['token'])) {
     if (!verifyToken($_POST['token'])) {
+        if (isset($_POST['type']) && $_POST['type'] === 'save') {
+            header('HTTP/1.1 409 Conflict');
+            header('Content-Type: text/plain; charset=UTF-8');
+            header('Cache-Control: no-store');
+            header('X-CSRF-Token: ' . $_SESSION['token']);
+            die("Invalid Token.");
+        }
         header('HTTP/1.0 401 Unauthorized');
         die("Invalid Token.");
     }
@@ -528,7 +546,10 @@ if ((isset($_SESSION[FM_SESSION_ID]['logged'], $auth_users[$_SESSION[FM_SESSION_
             header("HTTP/1.1 500 Internal Server Error");
             die("Could Not Write File! - Check Permissions / Ownership");
         }
-        die(true);
+        header('X-TFM-Save-Success: 1');
+        header('Content-Type: text/plain; charset=UTF-8');
+        header('Cache-Control: no-store');
+        die('1');
     }
 
     // backup files
@@ -4942,16 +4963,31 @@ function fm_show_header_login()
                             url: window.location,
                             data: JSON.stringify(data),
                             contentType: "application/json; charset=utf-8",
-                            success: function(mes) {
-                                toast("<?php echo lng("Saved Successfully"); ?>");
-                                window.onbeforeunload = function() {
-                                    return
+                            success: function(mes, textStatus, xhr) {
+                                var saveConfirmed = xhr.getResponseHeader("X-TFM-Save-Success") === "1" || String(mes).trim() === "1";
+                                if (saveConfirmed) {
+                                    toast("<?php echo lng("Saved Successfully"); ?>");
+                                    window.onbeforeunload = function() {
+                                        return
+                                    }
+                                } else {
+                                    alert("The file was not saved. The server returned an unexpected response:\n\n" + String(mes).trim().substring(0, 500));
                                 }
                             },
                             failure: function(mes) {
                                 toast("<?php echo lng("Error: try again"); ?>");
                             },
                             error: function(mes) {
+                                var refreshedToken = mes.getResponseHeader("X-CSRF-Token");
+                                if (mes.status === 409 && refreshedToken) {
+                                    window.csrf = refreshedToken;
+                                    alert("Your session was renewed. The file was not saved. The security token has been refreshed. Click Save again to confirm.");
+                                    return;
+                                }
+                                if (mes.status === 401) {
+                                    alert("Session expired. The file was not saved. Log in again in another tab, then click Save again.");
+                                    return;
+                                }
                                 toast(`<p style="background-color:red">${mes.responseText}</p>`);
                             }
                         });


### PR DESCRIPTION
### Summary

This fixes a misleading success message in the editor save flow when the session has expired or when the editor still uses an outdated CSRF token.

### Problem

Currently, JSON/AJAX save requests are handled only after the login check. If the session has expired, the login page can be returned with HTTP 200. The JavaScript success handler may then show `Saved Successfully`, although the file was not saved.

This is not only a cosmetic issue. I have personally lost editor changes several times because the UI reported a successful save while the file was not actually written.

There is a second related case: after logging in again in another tab, an already open editor can still contain an outdated CSRF token.

### Changes

* Detect real `application/json` AJAX save requests before the normal login check.
* Return HTTP 401 for expired sessions instead of the login page.
* Return HTTP 409 for stale CSRF tokens and provide the current token in the `X-CSRF-Token` response header.
* Return save error responses as `text/plain` with `Cache-Control: no-store`.
* Do not automatically save after receiving a refreshed CSRF token.
* Show a persistent message asking the user to click save again intentionally.
* Add `X-TFM-Save-Success: 1` as a clear server-side confirmation for successful saves.
* Show `Saved Successfully` only when this success header is present, or as a compatibility fallback when the trimmed server response is exactly `1`.
* Report unexpected HTTP 200 responses as failed saves and show a limited response excerpt for diagnostics.

### Expected behavior

1. The session expires while an editor tab is open.
2. The user tries to save.
3. The user receives a clear message that the file was not saved.
4. The user logs in again in another tab.
5. On the next save click in the old editor, only the CSRF token is refreshed.
6. The file is saved only after another intentional save click.

### Notes

This change is limited to the editor save flow and should not affect normal form posts or uploads.
