### PR TITLE
Remove finfo_close call in MIME type detection

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2588,6 +2588,9 @@ function fm_get_mime_type($file_path)
     if (function_exists('finfo_open')) {
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
         $mime = finfo_file($finfo, $file_path);
+        if (\PHP_VERSION_ID < 80000) {
+            finfo_close($finfo);
+        }
         return $mime;
     } elseif (function_exists('mime_content_type')) {
         return mime_content_type($file_path);

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2588,7 +2588,6 @@ function fm_get_mime_type($file_path)
     if (function_exists('finfo_open')) {
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
         $mime = finfo_file($finfo, $file_path);
-        finfo_close($finfo);
         return $mime;
     } elseif (function_exists('mime_content_type')) {
         return mime_content_type($file_path);


### PR DESCRIPTION
Remove unnecessary finfo_close call after retrieving MIME type for PHP 8.5 compatibility.

`finfo_close()` was deprecated in PHP 8.5 as a no-op function left over from the resource-to-object migration of ext/fileinfo (which happened in PHP 8.1).

Starting from PHP 8.5, calling `finfo_close()` generates:
```Deprecated: Function finfo_close() is deprecated since 8.5, as finfo objects are freed automatically```

Remove the `finfo_close($finfo)` call from `fm_get_mime_type()`.
The `$finfo` variable is local to the function and is released automatically when the function returns — this has always been true in all PHP versions (5.3+).  Since PHP 8.1 the call was already a no-op; in PHP 8.5 it became a deprecation. 
https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_finfo_close