### PR TITLE
Prevent redundant file reading.

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2727,7 +2727,10 @@ function fm_is_exclude_items($name, $path)
 function fm_get_translations($tr)
 {
     try {
-        static $content = @file_get_contents('translation.json');
+        if (!isset($content)) {
+            static $content = '';
+            $content = @file_get_contents('translation.json');
+        }
         if ($content !== FALSE) {
             $lng = json_decode($content, TRUE);
             global $lang_list;

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2727,8 +2727,8 @@ function fm_is_exclude_items($name, $path)
 function fm_get_translations($tr)
 {
     try {
-        static $content = '';
-        if ($content === '') {
+        static $content = null;
+        if ($content === null) {
             $content = @file_get_contents('translation.json');
         }
         if ($content !== FALSE) {

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2727,7 +2727,7 @@ function fm_is_exclude_items($name, $path)
 function fm_get_translations($tr)
 {
     try {
-        $content = @file_get_contents('translation.json');
+        static $content = @file_get_contents('translation.json');
         if ($content !== FALSE) {
             $lng = json_decode($content, TRUE);
             global $lang_list;

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -2727,8 +2727,8 @@ function fm_is_exclude_items($name, $path)
 function fm_get_translations($tr)
 {
     try {
-        if (!isset($content)) {
-            static $content = '';
+        static $content = '';
+        if ($content === '') {
             $content = @file_get_contents('translation.json');
         }
         if ($content !== FALSE) {


### PR DESCRIPTION
When running Tiny File Manager, under normal circumstances, after logging in, I found that the `file_get_contents('translation.json')` call would execute 393 times.

Whether the initial read would actually be already cached and subsequent reads being read from that cache, or whether the translations file would actually, literally be read in 393 times per each request is unclear, as the function interacts with the underlying file system and the exact behaviour is therefore OS dependent. However, PHP itself does not cache the results of this function, so it would be best to assume, from a development perspective, that it isn't being cached.

As we don't expect the content of the translations file to change during the period of a singular request, we only need the file to be read once.

To prevent *potential* redundant reading of the file beyond the initial read, this pull request adds the `static` keyword to the line in question.

Ideally, at *some* point, the entire translation system should probably be refactored and reworked a little, but as we already have 65 open pull requests at this time, at least several of them concerning aspects of the translation system whether that be the addition of new translations, corrections to existing translations, or whatever else, I'm apprehensive for any additional pull requests I create to contain changes any larger than is absolutely necessary, due to the risk of either generating merge conflicts for other requests or of being affected by them (depending on the order in which pull requests are eventually merged), and due to the limited availability of time for maintainers to work through them all. This particular pull request is somewhat of a band-aid solution in that sense, but it should get the job done: When implemented, the call will only be executed once, instead of 393 times, and the change doesn't break anything (testing locally, everything still appears the same as it did before, no errors generated, all translations appearing correctly, etc).