### PR TITLE
Add optional proxy support for URL uploads

### DIFF
--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -163,6 +163,10 @@ $ext_language = array(
     'htaccess' => 'apache_conf',
 );
 
+// Proxy for URL Download Support (hostname:port)
+// Note: configure the proxy for the URLs the server is allowed to reach.
+//$proxyServer = 'proxy.url.tld:8080';
+
 // if User has the external config file, try to use it to override the default config above [config.php]
 // sample config - https://tinyfilemanager.github.io/config-sample.txt
 $config_file = __DIR__ . '/config.php';
@@ -674,7 +678,12 @@ if ((isset($_SESSION[FM_SESSION_ID]['logged'], $auth_users[$_SESSION[FM_SESSION_
             $fileinfo->size = $curl_info["size_download"];
             $fileinfo->type = $curl_info["content_type"];
         } else {
-            $ctx = stream_context_create();
+            if (isset($proxyServer)) {
+                $opts = array('http' => array('proxy' => 'tcp://' . $proxyServer, 'request_fulluri' => true));
+                $ctx = stream_context_create($opts);
+            } else {
+                $ctx = stream_context_create();
+            }
             @$success = copy($url, $temp_file, $ctx);
             if (!$success) {
                 $err = error_get_last();


### PR DESCRIPTION
## Summary

- Add an optional proxyServer configuration for server-side URL uploads.
- Apply the proxy only to the PHP stream-wrapper path when cURL is unavailable.
- Preserve the existing direct behavior when no proxy is configured.

## Validation

- git diff --check
- PHP 7.4 syntax check for tinyfilemanager.php