### PR TITLE
Add maintained Apache/PHP container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.git/**
+/contrib/container/config.php

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 *.php text eol=lf
 *.json text eol=lf
+contrib/container/Dockerfile text eol=lf
+contrib/container/container-entrypoint text eol=lf
+contrib/container/container-healthcheck text eol=lf
+contrib/container/hash-password text eol=lf

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Tinyfilemanager is highly documented on the [wiki pages](https://github.com/pras
 - PHP 5.5.0 or higher.
 - Fileinfo, iconv, zip, tar and mbstring extensions are strongly recommended.
 
+## Containers
+
+The maintained Apache/PHP container, Compose file, and quick start are in
+[`contrib/container`](contrib/container/README.md).
+
 ## How to use
 
 Download ZIP with latest version from master branch.

--- a/contrib/container/.gitignore
+++ b/contrib/container/.gitignore
@@ -1,0 +1,1 @@
+/config.php

--- a/contrib/container/Dockerfile
+++ b/contrib/container/Dockerfile
@@ -1,0 +1,69 @@
+# syntax=docker/dockerfile:1@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
+
+ARG PHP_IMAGE=php:8.3.33-apache-bookworm@sha256:69e641a40929c9db9d1ce43b982d46f6701ccdd5f7b4c32d5bd773cae6882393
+FROM ${PHP_IMAGE}
+
+LABEL org.opencontainers.image.title="Tiny File Manager" \
+      org.opencontainers.image.description="Local-filesystem Tiny File Manager service" \
+      org.opencontainers.image.source="https://github.com/prasathmani/tinyfilemanager" \
+      org.opencontainers.image.lifecycle="trusted-local-non-production"
+
+# Build ZipArchive and retain only its runtime libraries. The other recommended
+# extensions are already present in the pinned official PHP image.
+RUN set -eux; \
+    saved_apt_mark="$(apt-mark showmanual)"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends libzip-dev=1.7.3-1+b1; \
+    docker-php-ext-install -j"$(nproc)" zip; \
+    apt-mark auto '.*' > /dev/null; \
+    if [ -n "$saved_apt_mark" ]; then apt-mark manual $saved_apt_mark; fi; \
+    find /usr/local -type f -executable -exec ldd '{}' ';' \
+      | awk '/=>/ { library = $(NF-1); if (index(library, "/usr/local/") == 1) next; gsub("^/(usr/)?", "", library); print "*" library }' \
+      | sort -u \
+      | xargs -r dpkg-query --search \
+      | awk 'sub(":$", "", $1) { print $1 }' \
+      | sort -u \
+      | xargs -r apt-mark manual; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*; \
+    php -r 'foreach (["fileinfo", "iconv", "mbstring", "posix", "zip"] as $extension) { if (!extension_loaded($extension)) { fwrite(STDERR, "missing PHP extension: $extension\n"); exit(1); } }'
+
+COPY tinyfilemanager.php /var/www/html/index.php
+COPY translation.json /var/www/html/translation.json
+COPY contrib/container/healthz.php /var/www/html/healthz.php
+COPY LICENSE /usr/share/licenses/tinyfilemanager/LICENSE
+COPY contrib/container/apache.conf /etc/apache2/conf-available/tinyfilemanager.conf
+COPY contrib/container/vhost.conf /etc/apache2/sites-available/tinyfilemanager.conf
+COPY contrib/container/php.ini /usr/local/etc/php/conf.d/tinyfilemanager.ini
+COPY contrib/container/container-entrypoint /usr/local/bin/container-entrypoint
+COPY contrib/container/container-healthcheck /usr/local/bin/container-healthcheck
+COPY contrib/container/hash-password /usr/local/bin/tinyfilemanager-hash-password
+COPY contrib/container/validate-config.php /usr/local/lib/tinyfilemanager/validate-config.php
+
+RUN set -eux; \
+    rm -f /var/www/html/index.html; \
+    install -d -o www-data -g www-data -m 0770 /srv/tinyfilemanager/data; \
+    install -m 000 /dev/null /var/www/html/config.php; \
+    chown -R root:root /var/www/html /usr/local/lib/tinyfilemanager; \
+    find /var/www/html /usr/local/lib/tinyfilemanager -type d -exec chmod 0555 '{}' +; \
+    find /var/www/html /usr/local/lib/tinyfilemanager -type f ! -name config.php -exec chmod 0444 '{}' +; \
+    chmod 0555 /usr/local/bin/container-entrypoint \
+      /usr/local/bin/container-healthcheck \
+      /usr/local/bin/tinyfilemanager-hash-password; \
+    a2enmod headers; \
+    a2enconf tinyfilemanager; \
+    a2dissite 000-default; \
+    a2ensite tinyfilemanager; \
+    php -l /var/www/html/index.php; \
+    php -l /var/www/html/healthz.php; \
+    php -l /usr/local/lib/tinyfilemanager/validate-config.php; \
+    apache2ctl configtest
+
+VOLUME ["/srv/tinyfilemanager/data"]
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["/usr/local/bin/container-healthcheck"]
+
+ENTRYPOINT ["/usr/local/bin/container-entrypoint"]
+CMD ["apache2-foreground"]

--- a/contrib/container/Dockerfile.dockerignore
+++ b/contrib/container/Dockerfile.dockerignore
@@ -1,0 +1,21 @@
+**
+
+!tinyfilemanager.php
+!translation.json
+!LICENSE
+!contrib/
+!contrib/container/
+!contrib/container/apache.conf
+!contrib/container/container-entrypoint
+!contrib/container/container-healthcheck
+!contrib/container/hash-password
+!contrib/container/healthz.php
+!contrib/container/php.ini
+!contrib/container/validate-config.php
+!contrib/container/vhost.conf
+
+# Runtime configuration and credentials must never enter the build context.
+contrib/container/config.php
+**/*.key
+**/*.pem
+**/secrets/**

--- a/contrib/container/README.md
+++ b/contrib/container/README.md
@@ -55,6 +55,28 @@ previews, online document viewing, and URL uploads. Managed files remain
 outside Apache's document root and downloads continue through the authenticated
 application.
 
+### Change the managed root
+
+Tiny File Manager's `$root_path` is separate from Apache's `DocumentRoot`.
+Keep Apache's document root at `/var/www/html` and mount a different host
+directory by replacing the `data` volume entry under `volumes:` in
+`compose.yaml`:
+
+```yaml
+- type: bind
+  source: /absolute/path/on/host
+  target: /srv/tinyfilemanager/data
+  bind:
+    create_host_path: false
+    selinux: Z
+```
+
+The host directory must be readable and writable by container UID/GID `33:33`.
+Do not mount managed files below `/var/www/html`, where Apache could serve them
+without Tiny File Manager authentication. To change the in-container path
+itself, update the Compose target, `$root_path` in `config.php`, and the fixed
+path in `validate-config.php`, then rebuild.
+
 For a TLS reverse proxy, set `$container_tls_proxy = true` so session cookies
 are marked `Secure`. Keep the container port on loopback, and configure the
 proxy to replace rather than append forwarded headers.
@@ -76,10 +98,7 @@ docker compose -f contrib/container/compose.yaml logs -f
 docker compose -f contrib/container/compose.yaml down
 ```
 
-The named data volume survives `down`. Running `down -v` deletes it. For a
-host bind mount instead, the data directory must be readable and writable by
-container UID/GID `33:33` and have an appropriate private label on SELinux
-hosts.
+The named data volume survives `down`. Running `down -v` deletes it.
 
 The built-in healthcheck is PHP/HTTP liveness only; it does not attest login,
 data integrity, or production readiness.

--- a/contrib/container/README.md
+++ b/contrib/container/README.md
@@ -1,0 +1,99 @@
+# Tiny File Manager container
+
+This builds a local-filesystem Tiny File Manager service. It requires an
+external configuration file, stores managed files outside Apache's document
+root, and listens on `127.0.0.1:8080` by default.
+
+Use a current Docker Engine with BuildKit and the `docker compose` plugin. Run
+all commands from the repository root and include the shown `-f` option.
+
+Choose a unique project name for this deployment. Compose refuses to run
+without it, preventing separate checkouts from sharing a data volume:
+
+```sh
+export TFM_PROJECT=tinyfilemanager-local
+```
+
+## Build
+
+```sh
+docker compose -f contrib/container/compose.yaml build
+```
+
+The equivalent direct build is:
+
+```sh
+docker build -f contrib/container/Dockerfile \
+  -t "tinyfilemanager:$TFM_PROJECT" .
+```
+
+## Configure
+
+Create the ignored runtime configuration:
+
+```sh
+cp contrib/container/config.php.example contrib/container/config.php
+```
+
+Generate a password hash without putting the password in the command line:
+
+```sh
+docker run --rm -it --entrypoint tinyfilemanager-hash-password \
+  "tinyfilemanager:$TFM_PROJECT"
+```
+
+Replace `REPLACE_WITH_PASSWORD_HASH` in `config.php` with the generated hash.
+Edit the user name, read-only users, and time zone as needed. The application
+upload limit may be lowered in `config.php`; raising the 256 MiB server limit
+also requires editing `php.ini` and rebuilding. Keep `$root_path` at
+`/srv/tinyfilemanager/data`; startup rejects missing credentials, placeholder
+credentials, and baseline-policy mismatches. Per-user directory mappings are
+not supported by this image.
+
+The supplied configuration disables settings changes, direct links, media
+previews, online document viewing, and URL uploads. Managed files remain
+outside Apache's document root and downloads continue through the authenticated
+application.
+
+For a TLS reverse proxy, set `$container_tls_proxy = true` so session cookies
+are marked `Secure`. Keep the container port on loopback, and configure the
+proxy to replace rather than append forwarded headers.
+
+## Start
+
+```sh
+docker compose -f contrib/container/compose.yaml up -d
+docker compose -f contrib/container/compose.yaml ps
+```
+
+Open <http://127.0.0.1:8080>. To use another host port, set `TFM_PORT`, for
+example `TFM_PORT=8081 docker compose -f contrib/container/compose.yaml up -d`.
+
+View logs or stop the service with:
+
+```sh
+docker compose -f contrib/container/compose.yaml logs -f
+docker compose -f contrib/container/compose.yaml down
+```
+
+The named data volume survives `down`. Running `down -v` deletes it. For a
+host bind mount instead, the data directory must be readable and writable by
+container UID/GID `33:33` and have an appropriate private label on SELinux
+hosts.
+
+The built-in healthcheck is PHP/HTTP liveness only; it does not attest login,
+data integrity, or production readiness.
+
+## Scope
+
+- This is a trusted-local, non-production image. Tiny File Manager follows
+  filesystem symlinks, so the data mount is not a confinement boundary. Do not
+  use restored/untrusted trees or trees containing symlinks.
+- `config.php` is trusted executable PHP. Start from the supplied example; do
+  not mount configuration obtained from another user or system.
+- The image has no TLS terminator. Keep the loopback binding or use the TLS
+  proxy mode above; do not expose it directly to an untrusted network.
+- The current UI loads assets from public CDNs, so this image is unsuitable
+  for controlled or protected data.
+- Never put passwords, private keys, or other secrets in the image or build
+  context. Mount runtime configuration read-only.

--- a/contrib/container/README.md
+++ b/contrib/container/README.md
@@ -4,14 +4,26 @@ This builds a local-filesystem Tiny File Manager service. It requires an
 external configuration file, stores managed files outside Apache's document
 root, and listens on `127.0.0.1:8080` by default.
 
-Use a current Docker Engine with BuildKit and the `docker compose` plugin. Run
-all commands from the repository root and include the shown `-f` option.
+## Requirements
+
+- Linux: a current Docker Engine with BuildKit and the `docker compose` plugin.
+- macOS or Windows: a current Docker Desktop using Linux containers.
+
+Run all commands from the repository root and include the shown `-f` option.
 
 Choose a unique project name for this deployment. Compose refuses to run
 without it, preventing separate checkouts from sharing a data volume:
 
+Linux or macOS:
+
 ```sh
 export TFM_PROJECT=tinyfilemanager-local
+```
+
+Windows PowerShell:
+
+```powershell
+$env:TFM_PROJECT = "tinyfilemanager-local"
 ```
 
 ## Build
@@ -20,26 +32,26 @@ export TFM_PROJECT=tinyfilemanager-local
 docker compose -f contrib/container/compose.yaml build
 ```
 
-The equivalent direct build is:
-
-```sh
-docker build -f contrib/container/Dockerfile \
-  -t "tinyfilemanager:$TFM_PROJECT" .
-```
-
 ## Configure
 
 Create the ignored runtime configuration:
+
+Linux or macOS:
 
 ```sh
 cp contrib/container/config.php.example contrib/container/config.php
 ```
 
+Windows PowerShell:
+
+```powershell
+Copy-Item contrib/container/config.php.example contrib/container/config.php
+```
+
 Generate a password hash without putting the password in the command line:
 
 ```sh
-docker run --rm -it --entrypoint tinyfilemanager-hash-password \
-  "tinyfilemanager:$TFM_PROJECT"
+docker compose -f contrib/container/compose.yaml run --rm --no-deps --entrypoint tinyfilemanager-hash-password tinyfilemanager
 ```
 
 Replace `REPLACE_WITH_PASSWORD_HASH` in `config.php` with the generated hash.
@@ -55,33 +67,72 @@ previews, online document viewing, and URL uploads. Managed files remain
 outside Apache's document root and downloads continue through the authenticated
 application.
 
-### Change the managed root
+### Serve an existing host directory
 
 Tiny File Manager's `$root_path` is separate from Apache's `DocumentRoot`.
-Keep Apache's document root at `/var/www/html` and mount a different host
-directory by replacing the `data` volume entry under `volumes:` in
-`compose.yaml`:
+Keep `$root_path` at `/srv/tinyfilemanager/data` and point that path at any
+dedicated, unshared host directory with the supplied Compose override. Choose
+this mode instead of the Docker-managed volume described below; do not mix the
+commands for the two modes.
 
-```yaml
-- type: bind
-  source: /absolute/path/on/host
-  target: /srv/tinyfilemanager/data
-  bind:
-    create_host_path: false
-    selinux: Z
+Linux:
+
+These UID commands assume rootful Docker. With rootless or
+user-namespace-remapped Docker, use the named volume unless UID 33 is mapped to
+the correct host UID. For a new directory, `mkdir` must succeed; stop and review
+permissions instead of continuing if the path already exists.
+
+```sh
+sudo mkdir -m 0750 /srv/tinyfilemanager-data &&
+  sudo chown 33:33 /srv/tinyfilemanager-data &&
+  export TFM_DATA_PATH=/srv/tinyfilemanager-data
 ```
 
-The host directory must be readable and writable by container UID/GID `33:33`.
-Do not mount managed files below `/var/www/html`, where Apache could serve them
-without Tiny File Manager authentication. To change the in-container path
-itself, update the Compose target, `$root_path` in `config.php`, and the fixed
-path in `validate-config.php`, then rebuild.
+For an existing dedicated tree, inspect and back up its ownership and ACLs,
+then grant numeric UID 33 read, write, and directory-search access with the
+host's ACL tools. Do not use recursive `chmod 0777` or blindly change ownership.
+
+macOS:
+
+```sh
+mkdir -p "$HOME/tinyfilemanager-data"
+export TFM_DATA_PATH="$HOME/tinyfilemanager-data"
+```
+
+Windows PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force "$HOME\tinyfilemanager-data" | Out-Null
+$env:TFM_DATA_PATH = "$HOME\tinyfilemanager-data"
+```
+
+On macOS and Windows, ensure Docker Desktop can share the selected path. The
+current host user must have read and write permission. If a Windows home
+directory is redirected to a network share, select a local drive path instead.
+
+On SELinux hosts, the override requests a private `Z` relabel. Never select
+`/`, an entire home or system directory, or a path shared with another service
+or container. Keep both `TFM_PROJECT` and `TFM_DATA_PATH` set in the same shell
+for every host-directory command.
+
+Start with the host directory:
+
+```sh
+docker compose -f contrib/container/compose.yaml -f contrib/container/compose.host-path.yaml up -d
+```
+
+Use both `-f` options for later `ps`, `logs`, and `down` commands. Do not mount
+managed files below `/var/www/html`, where Apache could serve them without Tiny
+File Manager authentication. Startup fails if the selected directory is not
+readable, writable, and searchable by the Apache worker.
 
 For a TLS reverse proxy, set `$container_tls_proxy = true` so session cookies
 are marked `Secure`. Keep the container port on loopback, and configure the
 proxy to replace rather than append forwarded headers.
 
-## Start
+## Start with a Docker-managed volume
+
+Use this mode only when `TFM_DATA_PATH` is not being used:
 
 ```sh
 docker compose -f contrib/container/compose.yaml up -d
@@ -89,7 +140,21 @@ docker compose -f contrib/container/compose.yaml ps
 ```
 
 Open <http://127.0.0.1:8080>. To use another host port, set `TFM_PORT`, for
-example `TFM_PORT=8081 docker compose -f contrib/container/compose.yaml up -d`.
+example:
+
+Linux or macOS:
+
+```sh
+export TFM_PORT=8081
+```
+
+Windows PowerShell:
+
+```powershell
+$env:TFM_PORT = "8081"
+```
+
+Then run the applicable `up -d` command again.
 
 View logs or stop the service with:
 
@@ -99,6 +164,7 @@ docker compose -f contrib/container/compose.yaml down
 ```
 
 The named data volume survives `down`. Running `down -v` deletes it.
+`down -v` does not delete a bind-mounted host directory.
 
 The built-in healthcheck is PHP/HTTP liveness only; it does not attest login,
 data integrity, or production readiness.

--- a/contrib/container/apache.conf
+++ b/contrib/container/apache.conf
@@ -1,0 +1,25 @@
+ServerTokens Prod
+ServerSignature Off
+ServerName localhost
+TraceEnable Off
+FileETag None
+DirectoryIndex index.php
+
+<Directory "/var/www/html">
+    Options -Indexes -Includes -ExecCGI
+    AllowOverride None
+    Require all granted
+</Directory>
+
+<Files "config.php">
+    Require all denied
+</Files>
+
+<Files "translation.json">
+    Require all denied
+</Files>
+
+Header always set X-Content-Type-Options "nosniff"
+Header always set X-Frame-Options "DENY"
+Header always set Referrer-Policy "same-origin"
+Header always set Permissions-Policy "camera=(), geolocation=(), microphone=()"

--- a/contrib/container/compose.host-path.yaml
+++ b/contrib/container/compose.host-path.yaml
@@ -1,0 +1,9 @@
+services:
+  tinyfilemanager:
+    volumes:
+      - type: bind
+        source: "${TFM_DATA_PATH:?Set TFM_DATA_PATH to an existing absolute host directory}"
+        target: /srv/tinyfilemanager/data
+        bind:
+          create_host_path: false
+          selinux: Z

--- a/contrib/container/compose.yaml
+++ b/contrib/container/compose.yaml
@@ -1,0 +1,42 @@
+name: ${TFM_PROJECT:?Set TFM_PROJECT to a unique Compose project name}
+
+services:
+  tinyfilemanager:
+    image: tinyfilemanager:${TFM_PROJECT}
+    build:
+      context: ../..
+      dockerfile: contrib/container/Dockerfile
+    init: true
+    restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - KILL
+      - NET_BIND_SERVICE
+      - SETGID
+      - SETUID
+    ports:
+      - "127.0.0.1:${TFM_PORT:-8080}:80"
+    volumes:
+      - type: bind
+        source: ./config.php
+        target: /var/www/html/config.php
+        read_only: true
+        bind:
+          create_host_path: false
+          selinux: Z
+      - type: volume
+        source: data
+        target: /srv/tinyfilemanager/data
+    tmpfs:
+      - /run:rw,nosuid,nodev,size=16m,mode=0755
+      - /tmp:rw,noexec,nosuid,nodev,size=256m,mode=1777
+    stop_grace_period: 20s
+
+volumes:
+  data:

--- a/contrib/container/config.php.example
+++ b/contrib/container/config.php.example
@@ -1,0 +1,37 @@
+<?php
+
+// Keep application redirects relative and independent of request Host headers.
+define('FM_SELF_URL', '/index.php');
+define('FM_ROOT_URL', '');
+
+// Generate this value with the command documented in README.md.
+$auth_users = array(
+    'admin' => 'REPLACE_WITH_PASSWORD_HASH',
+);
+
+$use_auth = true;
+$readonly_users = array();
+$directories_users = array();
+$global_readonly = false;
+
+// Managed data stays outside Apache's document root.
+$root_path = '/srv/tinyfilemanager/data';
+$root_url = '';
+$path_display_mode = 'relative';
+
+$default_timezone = 'Etc/UTC';
+$max_upload_size_bytes = 268435456; // 256 MiB
+$upload_chunk_size_bytes = 2097152; // 2 MiB
+
+// Set true only when every browser request arrives through a TLS proxy.
+$container_tls_proxy = false;
+if ($container_tls_proxy) {
+    ini_set('session.cookie_secure', '1');
+}
+
+// Safer defaults for a self-hosted local-filesystem service.
+$online_viewer = false;
+$settings_enabled = false;
+$direct_links_enabled = false;
+$raw_previews_enabled = false;
+$url_upload_enabled = false;

--- a/contrib/container/container-entrypoint
+++ b/contrib/container/container-entrypoint
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+fail() {
+    printf 'tinyfilemanager: %s\n' "$1" >&2
+    exit 1
+}
+
+if [ "${1:-}" = "apache2-foreground" ]; then
+    config=/var/www/html/config.php
+    data_root=/srv/tinyfilemanager/data
+
+    [ -s "$config" ] \
+        || fail 'mount a non-empty config.php at /var/www/html/config.php'
+    runuser -u www-data -- test -r "$config" \
+        || fail 'config.php must be readable by the Apache worker'
+    if runuser -u www-data -- test -w "$config"; then
+        fail 'config.php must be mounted read-only'
+    fi
+    if grep -Fq 'REPLACE_WITH_PASSWORD_HASH' "$config"; then
+        fail 'replace the placeholder password hash in config.php'
+    fi
+
+    php -l "$config" > /dev/null
+    runuser -u www-data -- php \
+        /usr/local/lib/tinyfilemanager/validate-config.php "$config"
+
+    [ -d "$data_root" ] || fail 'the data volume is not mounted'
+    runuser -u www-data -- test -r "$data_root" \
+        || fail 'the data directory is not readable by UID 33'
+    runuser -u www-data -- test -w "$data_root" \
+        || fail 'the data directory is not writable by UID 33'
+    runuser -u www-data -- test -x "$data_root" \
+        || fail 'the data directory is not searchable by UID 33'
+
+    install -d -m 0755 /run/apache2 /run/lock/apache2
+    install -d -o www-data -g www-data -m 0700 \
+        /tmp/tinyfilemanager-sessions /tmp/tinyfilemanager-uploads
+fi
+
+exec "$@"

--- a/contrib/container/container-healthcheck
+++ b/contrib/container/container-healthcheck
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+exec php -r '
+$socket = @fsockopen("127.0.0.1", 80, $errorCode, $errorMessage, 2);
+if ($socket === false) {
+    exit(1);
+}
+fwrite($socket, "GET /healthz.php HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+$status = fgets($socket);
+fclose($socket);
+exit(is_string($status) && preg_match("~^HTTP/[0-9.]+ 204 ~", $status) ? 0 : 1);
+'

--- a/contrib/container/hash-password
+++ b/contrib/container/hash-password
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+if [ ! -t 0 ]; then
+    printf 'A terminal is required so the password is not echoed.\n' >&2
+    exit 1
+fi
+
+terminal_state=$(stty -g)
+restore_terminal() {
+    stty "$terminal_state" 2>/dev/null || true
+}
+trap restore_terminal EXIT HUP INT TERM
+
+printf 'Password: ' >&2
+stty -echo
+IFS= read -r password
+printf '\nConfirm password: ' >&2
+IFS= read -r confirmation
+restore_terminal
+trap - EXIT HUP INT TERM
+printf '\n' >&2
+
+[ "$password" = "$confirmation" ] || {
+    printf 'Passwords do not match.\n' >&2
+    exit 1
+}
+[ "${#password}" -ge 12 ] || {
+    printf 'Password must contain at least 12 characters.\n' >&2
+    exit 1
+}
+
+printf '%s' "$password" | php -r '
+$password = stream_get_contents(STDIN);
+echo password_hash($password, PASSWORD_DEFAULT), PHP_EOL;
+'
+
+unset password confirmation

--- a/contrib/container/healthz.php
+++ b/contrib/container/healthz.php
@@ -1,0 +1,3 @@
+<?php
+
+http_response_code(204);

--- a/contrib/container/php.ini
+++ b/contrib/container/php.ini
@@ -1,0 +1,22 @@
+expose_php = Off
+display_errors = Off
+log_errors = On
+error_reporting = E_ALL
+
+memory_limit = 512M
+upload_max_filesize = 256M
+post_max_size = 260M
+max_execution_time = 300
+max_input_time = 300
+upload_tmp_dir = /tmp/tinyfilemanager-uploads
+sys_temp_dir = /tmp
+
+allow_url_fopen = Off
+disable_functions = exec,passthru,popen,proc_open,shell_exec,system
+session.save_path = /tmp/tinyfilemanager-sessions
+session.use_only_cookies = 1
+session.use_strict_mode = 1
+session.use_trans_sid = 0
+session.cookie_httponly = 1
+session.cookie_secure = 0
+session.cookie_samesite = Lax

--- a/contrib/container/validate-config.php
+++ b/contrib/container/validate-config.php
@@ -1,0 +1,121 @@
+<?php
+
+if (PHP_SAPI !== 'cli' || $argc !== 2) {
+    fwrite(STDERR, "invalid configuration-validator invocation\n");
+    exit(2);
+}
+
+$use_auth = null;
+$auth_users = null;
+$readonly_users = null;
+$directories_users = null;
+$global_readonly = null;
+$root_path = null;
+$root_url = null;
+$path_display_mode = null;
+$container_tls_proxy = null;
+$online_viewer = null;
+$settings_enabled = null;
+$direct_links_enabled = null;
+$raw_previews_enabled = null;
+$url_upload_enabled = null;
+
+$constantsBefore = get_defined_constants();
+ob_start();
+include $argv[1];
+$output = ob_get_clean();
+$constantsAfter = get_defined_constants();
+
+$errors = array();
+if ($output !== '') {
+    $errors[] = 'config.php must not produce output';
+}
+if ($use_auth !== true) {
+    $errors[] = 'local authentication must be enabled';
+}
+if (!is_array($auth_users) || $auth_users === array()) {
+    $errors[] = 'at least one local user is required';
+} else {
+    $defaultHashes = array(
+        '$2y$10$/K.hjNr84lLNDt8fTXjoI.DBp6PpeyoJ.mGwrrLuCZfAwfSAGqhOW',
+        '$2y$10$Fg6Dz8oH9fPoZ2jJan5tZuv6Z4Kp7avtQ9bDfrdRntXtPeiMAZyGO',
+    );
+    foreach ($auth_users as $name => $hash) {
+        $hashInfo = is_string($hash) ? password_get_info($hash) : array();
+        if (!is_string($name) || $name === '') {
+            $errors[] = 'user names must be non-empty strings';
+        }
+        if (!is_string($hash)
+            || in_array($hash, $defaultHashes, true)
+            || !isset($hashInfo['algoName'])
+            || $hashInfo['algoName'] === 'unknown') {
+            $errors[] = 'every user must have a non-default password_hash value';
+        }
+    }
+}
+if (!is_array($readonly_users)) {
+    $errors[] = 'readonly_users must be an array';
+}
+if (!is_bool($global_readonly)) {
+    $errors[] = 'global_readonly must be a boolean';
+}
+if ($directories_users !== array()) {
+    $errors[] = 'per-user data roots are not supported by this container';
+}
+if ($root_path !== '/srv/tinyfilemanager/data' || $root_url !== '') {
+    $errors[] = 'the data root must remain outside the Apache document root';
+}
+if ($path_display_mode !== 'relative') {
+    $errors[] = 'path display mode must remain relative';
+}
+$allowedConstants = array(
+    'FM_ROOT_URL' => '',
+    'FM_SELF_URL' => '/index.php',
+);
+$newConstants = array_diff_key($constantsAfter, $constantsBefore);
+foreach ($newConstants as $name => $value) {
+    if (!array_key_exists($name, $allowedConstants)
+        || $value !== $allowedConstants[$name]) {
+        $errors[] = 'config.php defined an unsupported constant';
+    }
+}
+foreach ($allowedConstants as $name => $value) {
+    if (!defined($name) || constant($name) !== $value) {
+        $errors[] = 'config.php must define the fixed relative URL constants';
+    }
+}
+if (!is_bool($container_tls_proxy)) {
+    $errors[] = 'container_tls_proxy must be a boolean';
+} else {
+    $secureCookie = filter_var(
+        ini_get('session.cookie_secure'), FILTER_VALIDATE_BOOLEAN);
+    if ($secureCookie !== $container_tls_proxy) {
+        $errors[] = 'TLS proxy mode and the Secure session cookie must match';
+    }
+}
+$requiredSessionSettings = array(
+    'session.use_only_cookies' => '1',
+    'session.use_strict_mode' => '1',
+    'session.use_trans_sid' => '0',
+    'session.cookie_httponly' => '1',
+    'session.cookie_samesite' => 'Lax',
+);
+foreach ($requiredSessionSettings as $name => $value) {
+    if ((string) ini_get($name) !== $value) {
+        $errors[] = 'required session hardening was changed';
+    }
+}
+if ($online_viewer !== false
+    || $settings_enabled !== false
+    || $direct_links_enabled !== false
+    || $raw_previews_enabled !== false
+    || $url_upload_enabled !== false) {
+    $errors[] = 'unsafe network and direct-access features must remain disabled';
+}
+
+if ($errors !== array()) {
+    foreach (array_unique($errors) as $error) {
+        fwrite(STDERR, "tinyfilemanager: $error\n");
+    }
+    exit(1);
+}

--- a/contrib/container/vhost.conf
+++ b/contrib/container/vhost.conf
@@ -1,0 +1,8 @@
+LogFormat "%a %t \"%m %U %H\" %>s %b" tinyfilemanager
+SetEnvIf Request_URI "^/healthz\.php$" tinyfilemanager_healthcheck
+
+<VirtualHost *:80>
+    DocumentRoot /var/www/html
+    ErrorLog /proc/self/fd/2
+    CustomLog /proc/self/fd/1 tinyfilemanager env=!tinyfilemanager_healthcheck
+</VirtualHost>

--- a/tinyfilemanager.php
+++ b/tinyfilemanager.php
@@ -107,6 +107,12 @@ $exclude_items = array();
 // false => disable online doc viewer
 $online_viewer = 'google';
 
+// Optional interfaces that may be disabled by an external configuration.
+$settings_enabled = true;
+$direct_links_enabled = true;
+$raw_previews_enabled = true;
+$url_upload_enabled = true;
+
 // Sticky Nav bar
 // true => enable sticky header
 // false => disable sticky header
@@ -451,6 +457,10 @@ defined('FM_FILE_EXTENSION') || define('FM_FILE_EXTENSION', $allowed_file_extens
 defined('FM_UPLOAD_EXTENSION') || define('FM_UPLOAD_EXTENSION', $allowed_upload_extensions);
 defined('FM_EXCLUDE_ITEMS') || define('FM_EXCLUDE_ITEMS', (version_compare(PHP_VERSION, '7.0.0', '<') ? serialize($exclude_items) : $exclude_items));
 defined('FM_DOC_VIEWER') || define('FM_DOC_VIEWER', $online_viewer);
+defined('FM_SETTINGS_ENABLED') || define('FM_SETTINGS_ENABLED', $settings_enabled === true);
+defined('FM_DIRECT_LINKS_ENABLED') || define('FM_DIRECT_LINKS_ENABLED', $direct_links_enabled === true);
+defined('FM_RAW_PREVIEWS_ENABLED') || define('FM_RAW_PREVIEWS_ENABLED', $raw_previews_enabled === true);
+defined('FM_URL_UPLOAD_ENABLED') || define('FM_URL_UPLOAD_ENABLED', $url_upload_enabled === true);
 define('FM_READONLY', $global_readonly || ($use_auth && !empty($readonly_users) && isset($_SESSION[FM_SESSION_ID]['logged']) && in_array($_SESSION[FM_SESSION_ID]['logged'], $readonly_users)));
 define('FM_IS_WIN', DIRECTORY_SEPARATOR == '\\');
 
@@ -498,6 +508,13 @@ if ((isset($_SESSION[FM_SESSION_ID]['logged'], $auth_users[$_SESSION[FM_SESSION_
     }
 
     if(FM_READONLY){
+        exit();
+    }
+
+    if (isset($_POST['type'])
+        && (($_POST['type'] == "settings" && !FM_SETTINGS_ENABLED)
+            || ($_POST['type'] == "upload" && !FM_URL_UPLOAD_ENABLED))) {
+        http_response_code(403);
         exit();
     }
 
@@ -1418,9 +1435,11 @@ if (isset($_GET['upload']) && !FM_READONLY) {
                     <li class="nav-item">
                         <a class="nav-link active" href="#fileUploader" data-target="#fileUploader"><i class="fa fa-arrow-circle-o-up"></i> <?php echo lng('UploadingFiles') ?></a>
                     </li>
+                    <?php if (FM_URL_UPLOAD_ENABLED): ?>
                     <li class="nav-item">
                         <a class="nav-link" href="#urlUploader" class="js-url-upload" data-target="#urlUploader"><i class="fa fa-link"></i> <?php echo lng('Upload from URL') ?></a>
                     </li>
+                    <?php endif; ?>
                 </ul>
             </div>
             <div class="card-body">
@@ -1438,6 +1457,7 @@ if (isset($_GET['upload']) && !FM_READONLY) {
                     </div>
                 </form>
 
+                <?php if (FM_URL_UPLOAD_ENABLED): ?>
                 <div class="upload-url-wrapper card-tabs-container hidden" id="urlUploader">
                     <form id="js-form-url-upload" class="row row-cols-lg-auto g-3 align-items-center" onsubmit="return upload_from_url(this);" method="POST" action="">
                         <input type="hidden" name="type" value="upload" aria-label="hidden" aria-hidden="true">
@@ -1452,6 +1472,7 @@ if (isset($_GET['upload']) && !FM_READONLY) {
                     </form>
                     <div id="js-url-upload__list" class="col-9 mt-3"></div>
                 </div>
+                <?php endif; ?>
             </div>
         </div>
     </div>
@@ -1591,7 +1612,11 @@ if (isset($_GET['copy']) && !isset($_GET['finish']) && !FM_READONLY) {
     exit;
 }
 
-if (isset($_GET['settings']) && !FM_READONLY) {
+if (isset($_GET['settings']) && !FM_SETTINGS_ENABLED) {
+    fm_redirect(FM_SELF_URL . '?p=' . urlencode(FM_PATH));
+}
+
+if (isset($_GET['settings']) && !FM_READONLY && FM_SETTINGS_ENABLED) {
     fm_show_header(); // HEADER
     fm_show_nav_path(FM_PATH); // current path
     global $cfg, $lang, $lang_list;
@@ -1851,7 +1876,9 @@ if (isset($_GET['view'])) {
                 <?php if (!FM_READONLY): ?>
                     <a class="fw-bold btn btn-outline-primary" title="<?php echo lng('Delete') ?>" href="?p=<?php echo urlencode(FM_PATH) ?>&amp;del=<?php echo urlencode($file) ?>" onclick="confirmDialog(event, 1209, '<?php echo lng('Delete') . ' ' . lng('File'); ?>','<?php echo urlencode($file); ?>', this.href);"> <i class="fa fa-trash"></i> Delete</a>
                 <?php endif; ?>
-                <a class="fw-bold btn btn-outline-primary" href="<?php echo fm_enc($file_url) ?>" target="_blank"><i class="fa fa-external-link-square"></i> <?php echo lng('Open') ?></a></b>
+                <?php if (FM_DIRECT_LINKS_ENABLED): ?>
+                    <a class="fw-bold btn btn-outline-primary" href="<?php echo fm_enc($file_url) ?>" target="_blank"><i class="fa fa-external-link-square"></i> <?php echo lng('Open') ?></a></b>
+                <?php endif; ?>
                 <?php
                 // ZIP actions
                 if (!FM_READONLY && ($is_zip || $is_gzip) && $filenames !== false) {
@@ -1904,15 +1931,15 @@ if (isset($_GET['view'])) {
                     } else {
                         echo '<p>' . lng('Error while fetching archive info') . '</p>';
                     }
-                } elseif ($is_image) {
+                } elseif ($is_image && FM_RAW_PREVIEWS_ENABLED) {
                     // Image content
                     if (in_array($ext, array('gif', 'jpg', 'jpeg', 'png', 'bmp', 'ico', 'svg', 'webp', 'avif'))) {
                         echo '<p><input type="checkbox" id="preview-img-zoomCheck"><label for="preview-img-zoomCheck"><img src="' . fm_enc($file_url) . '" alt="image" class="preview-img"></label></p>';
                     }
-                } elseif ($is_audio) {
+                } elseif ($is_audio && FM_RAW_PREVIEWS_ENABLED) {
                     // Audio content
                     echo '<p><audio src="' . fm_enc($file_url) . '" controls preload="metadata"></audio></p>';
-                } elseif ($is_video) {
+                } elseif ($is_video && FM_RAW_PREVIEWS_ENABLED) {
                     // Video content
                     echo '<div class="preview-video"><video src="' . fm_enc($file_url) . '" width="640" height="360" controls preload="metadata"></video></div>';
                 } elseif ($is_text) {
@@ -2241,7 +2268,9 @@ $all_files_size = 0;
                             <a title="<?php echo lng('Rename') ?>" href="#" onclick="rename('<?php echo fm_enc(addslashes(FM_PATH)) ?>', '<?php echo fm_enc(addslashes($f)) ?>');return false;"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></a>
                             <a title="<?php echo lng('CopyTo') ?>..." href="?p=&amp;copy=<?php echo urlencode(trim(FM_PATH . '/' . $f, '/')) ?>"><i class="fa fa-files-o" aria-hidden="true"></i></a>
                         <?php endif; ?>
-                        <a title="<?php echo lng('DirectLink') ?>" href="<?php echo fm_enc(FM_ROOT_URL . (FM_PATH != '' ? '/' . FM_PATH : '') . '/' . $f . '/') ?>" target="_blank"><i class="fa fa-link" aria-hidden="true"></i></a>
+                        <?php if (FM_DIRECT_LINKS_ENABLED): ?>
+                            <a title="<?php echo lng('DirectLink') ?>" href="<?php echo fm_enc(FM_ROOT_URL . (FM_PATH != '' ? '/' . FM_PATH : '') . '/' . $f . '/') ?>" target="_blank"><i class="fa fa-link" aria-hidden="true"></i></a>
+                        <?php endif; ?>
                     </td>
                 </tr>
             <?php
@@ -2292,7 +2321,7 @@ $all_files_size = 0;
                     <td data-sort=<?php echo fm_enc($f) ?>>
                         <div class="filename">
                             <?php
-                            if (in_array(strtolower(pathinfo($f, PATHINFO_EXTENSION)), array('gif', 'jpg', 'jpeg', 'png', 'bmp', 'ico', 'svg', 'webp', 'avif'))): ?>
+                            if (FM_RAW_PREVIEWS_ENABLED && in_array(strtolower(pathinfo($f, PATHINFO_EXTENSION)), array('gif', 'jpg', 'jpeg', 'png', 'bmp', 'ico', 'svg', 'webp', 'avif'))): ?>
                                 <?php $imagePreview = fm_enc(FM_ROOT_URL . (FM_PATH != '' ? '/' . FM_PATH : '') . '/' . $f); ?>
                                 <a href="<?php echo $filelink ?>" data-preview-image="<?php echo $imagePreview ?>" title="<?php echo fm_enc($f) ?>">
                                 <?php else: ?>
@@ -2319,7 +2348,9 @@ $all_files_size = 0;
                             <a title="<?php echo lng('CopyTo') ?>..."
                                 href="?p=<?php echo urlencode(FM_PATH) ?>&amp;copy=<?php echo urlencode(trim(FM_PATH . '/' . $f, '/')) ?>"><i class="fa fa-files-o"></i></a>
                         <?php endif; ?>
-                        <a title="<?php echo lng('DirectLink') ?>" href="<?php echo fm_enc(FM_ROOT_URL . (FM_PATH != '' ? '/' . FM_PATH : '') . '/' . $f) ?>" target="_blank"><i class="fa fa-link"></i></a>
+                        <?php if (FM_DIRECT_LINKS_ENABLED): ?>
+                            <a title="<?php echo lng('DirectLink') ?>" href="<?php echo fm_enc(FM_ROOT_URL . (FM_PATH != '' ? '/' . FM_PATH : '') . '/' . $f) ?>" target="_blank"><i class="fa fa-link"></i></a>
+                        <?php endif; ?>
                         <a title="<?php echo lng('Download') ?>" href="?p=<?php echo urlencode(FM_PATH) ?>&amp;dl=<?php echo urlencode($f) ?>" onclick="confirmDialog(event, 1211, '<?php echo lng('Download'); ?>','<?php echo urlencode($f); ?>', this.href);"><i class="fa fa-download"></i></a>
                     </td>
                 </tr>
@@ -3808,7 +3839,7 @@ function fm_show_nav_path($path)
                             </a>
 
                             <div class="dropdown-menu dropdown-menu-end text-small shadow" aria-labelledby="navbarDropdownMenuLink-5" data-bs-theme="<?php echo FM_THEME; ?>">
-                                <?php if (!FM_READONLY): ?>
+                                <?php if (!FM_READONLY && FM_SETTINGS_ENABLED): ?>
                                     <a title="<?php echo lng('Settings') ?>" class="dropdown-item nav-link" href="?p=<?php echo urlencode(FM_PATH) ?>&amp;settings=1"><i class="fa fa-cog" aria-hidden="true"></i> <?php echo lng('Settings') ?></a>
                                 <?php endif ?>
                                 <a title="<?php echo lng('Help') ?>" class="dropdown-item nav-link" href="?p=<?php echo urlencode(FM_PATH) ?>&amp;help=2"><i class="fa fa-exclamation-circle" aria-hidden="true"></i> <?php echo lng('Help') ?></a>
@@ -3816,7 +3847,7 @@ function fm_show_nav_path($path)
                             </div>
                         </li>
                     <?php else: ?>
-                        <?php if (!FM_READONLY): ?>
+                        <?php if (!FM_READONLY && FM_SETTINGS_ENABLED): ?>
                             <li class="nav-item">
                                 <a title="<?php echo lng('Settings') ?>" class="dropdown-item nav-link" href="?p=<?php echo urlencode(FM_PATH) ?>&amp;settings=1"><i class="fa fa-cog" aria-hidden="true"></i> <?php echo lng('Settings') ?></a>
                             </li>


### PR DESCRIPTION
## Summary

- add a maintained Apache/PHP image and Compose setup under `contrib/container`
- keep runtime configuration external and managed data outside the web root
- add opt-in generic feature gates needed by the container security profile
- document configuration, build, start, logs, and shutdown

## Validation

- Docker Buildx checks pass
- Compose configuration passes and requires a deployment-specific project name
- image builds from pristine upstream source
- runtime smoke covers health, login, create/edit/download, persistence, feature gates, private-file denial, read-only root filesystem, TLS session cookies, and query-free logs
